### PR TITLE
DATAVIC-935 DELWP Harvest Deletion Safeguard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Tests
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
 jobs:
   test:
     name: CKAN 2.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Tests
+on: [push, pull_request]
+jobs:
+  test:
+    name: CKAN 2.11
+    runs-on: ubuntu-latest
+    container:
+      image: ckan/ckan-dev:2.11-py3.10
+      options: --user root
+    services:
+      solr:
+        image: ckan/ckan-solr:2.11-solr9
+      postgres:
+        image: ckan/ckan-postgres-dev:2.11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      redis:
+        image: redis:7
+    env:
+      CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
+      CKAN_DATASTORE_WRITE_URL: postgresql://datastore_write:pass@postgres/datastore_test
+      CKAN_DATASTORE_READ_URL: postgresql://datastore_read:pass@postgres/datastore_test
+      CKAN_SOLR_URL: http://solr:8983/solr/ckan
+      CKAN_REDIS_URL: redis://redis:6379/1
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install requirements
+      run: |
+        pip install -r requirements.txt
+        pip install -r dev-requirements.txt
+        pip install -r requirements-ci.txt
+        pip install -e .
+        # Replace default path to CKAN core config file with the one on the container
+        sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test-ci.ini
+    - name: Setup extension
+      run: |
+        ckan -c test-ci.ini db init
+        ckan -c test-ci.ini db pending-migrations --apply
+    - name: Run tests
+      run: pytest --ckan-ini=test-ci.ini ckanext/datavic_harvester/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       CKAN_REDIS_URL: redis://redis:6379/1
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install requirements
       run: |
         pip install -r requirements.txt
@@ -37,8 +37,6 @@ jobs:
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test-ci.ini
     - name: Setup extension
-      run: |
-        ckan -c test-ci.ini db init
-        ckan -c test-ci.ini db pending-migrations --apply
+      run: ckan -c test-ci.ini db upgrade
     - name: Run tests
       run: pytest --ckan-ini=test-ci.ini ckanext/datavic_harvester/tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,9 @@ jobs:
     - name: Setup extension
       run: ckan -c test-ci.ini db upgrade
     - name: Run tests
-      run: pytest --ckan-ini=test-ci.ini ckanext/datavic_harvester/tests
+      run: pytest --ckan-ini=test-ci.ini --cov=ckanext.datavic_harvester --cov-report=term-missing --disable-warnings --junit-xml=/tmp/junit/results.xml ckanext/datavic_harvester/tests
+    - name: Test Summary
+      uses: test-summary/action@v2
+      with:
+        paths: /tmp/junit/results.xml
+      if: always()

--- a/README.md
+++ b/README.md
@@ -27,7 +27,44 @@ To install ``ckanext-datavic-harvester``:
 
 5. When creating a new harvest source via the standard ``ckanext-harvest`` admin UI, select ``CKAN Harvester for Data.Vic`` as the harvest type.
 
+## Running tests
+
+Tests run inside the CKAN Docker container against a dedicated test database.
+Test configuration is in ``pytest.ini`` and ``test.ini``. Tests use a separate
+``ckan_test`` postgres database and the ``solr``/``redis`` services already
+running in the stack.
+
+Start the stack (if not already running):
+
+        ahoy up
+
+Create the test database (one-time setup; the main ``ckan`` DB is not used for tests):
+
+        ahoy ckan
+        psql postgresql://ckan:ckan@postgres/postgres -c "CREATE DATABASE ckan_test OWNER ckan;"
+
+Run all tests (inside the CKAN container; `ahoy ckan` activates the virtualenv for you):
+
+        ahoy ckan
+        cd /app/src/ckanext-datavic-harvester && pytest ckanext/datavic_harvester/tests/
+
+Run a specific test file:
+
+        ahoy ckan
+        cd /app/src/ckanext-datavic-harvester && pytest ckanext/datavic_harvester/tests/harvesters/delwp/test_delwp.py
+
+Run a single test by name:
+
+        ahoy ckan
+        cd /app/src/ckanext-datavic-harvester && pytest ckanext/datavic_harvester/tests/ -k test_import_stage
+
+Stop on first failure with verbose output:
+
+        ahoy ckan
+        cd /app/src/ckanext-datavic-harvester && pytest ckanext/datavic_harvester/tests/ -x -v
+
 ## Additional Parameters
+
 ### ignore_private_datasets
 
 This setting can be used on the Public data.vic harvest from the Data Directory to exclude Private records from being harvested.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,23 @@ Stop on first failure with verbose output:
         ahoy ckan
         cd /app/src/ckanext-datavic-harvester && pytest ckanext/datavic_harvester/tests/ -x -v
 
+## Running CI locally with act
+
+The GitHub Actions workflow (`.github/workflows/test.yml`) can be run locally
+using [act](https://github.com/nektos/act). This is useful for validating CI
+changes before pushing.
+
+Install act (macOS):
+
+        brew install act
+
+Run the full test workflow:
+
+        act push --container-architecture linux/amd64
+
+The `--container-architecture` flag is required on Apple Silicon to match the
+`linux/amd64` images used by GitHub Actions. On Intel Macs it can be omitted.
+
 ## Additional Parameters
 
 ### ignore_private_datasets

--- a/ckanext/datavic_harvester/harvesters/delwp.py
+++ b/ckanext/datavic_harvester/harvesters/delwp.py
@@ -11,6 +11,7 @@ from os import path
 from typing import Iterator, Optional, Any
 
 from bs4 import BeautifulSoup, Tag
+import requests
 from sqlalchemy import and_, or_
 
 from ckan import model
@@ -68,11 +69,77 @@ class DelwpHarvester(DataVicBaseHarvester):
             raise ValueError("api_auth must be set")
 
         if "organisation_mapping" not in config_obj:
+            self._validate_optional_deletion_safeguard_config(config_obj)
             return json.dumps(config_obj, indent=4)
 
         self._validate_organisation_mapping(config_obj)
+        self._validate_optional_deletion_safeguard_config(config_obj)
 
         return json.dumps(config_obj, indent=4)
+
+    def _validate_optional_deletion_safeguard_config(
+        self, config: dict[str, Any]
+    ) -> None:
+        if "deletion_safeguard_enabled" in config:
+            v = config["deletion_safeguard_enabled"]
+            if isinstance(v, bool):
+                pass
+            elif isinstance(v, str):
+                try:
+                    config["deletion_safeguard_enabled"] = tk.asbool(v)
+                except ValueError as e:
+                    raise ValueError(
+                        "deletion_safeguard_enabled must be a boolean"
+                    ) from e
+            else:
+                raise ValueError("deletion_safeguard_enabled must be a boolean")
+
+        if "deletion_safeguard_allow_bulk_delete" in config:
+            v = config["deletion_safeguard_allow_bulk_delete"]
+            if isinstance(v, bool):
+                pass
+            elif isinstance(v, str):
+                try:
+                    config["deletion_safeguard_allow_bulk_delete"] = tk.asbool(v)
+                except ValueError as e:
+                    raise ValueError(
+                        "deletion_safeguard_allow_bulk_delete must be a boolean"
+                    ) from e
+            else:
+                raise ValueError("deletion_safeguard_allow_bulk_delete must be a boolean")
+
+        if "deletion_safeguard_drop_threshold_percent" in config:
+            try:
+                drop_threshold_percent = float(
+                    config["deletion_safeguard_drop_threshold_percent"]
+                )
+            except (TypeError, ValueError):
+                raise ValueError(
+                    "deletion_safeguard_drop_threshold_percent must be a number"
+                )
+
+            if drop_threshold_percent < 0 or drop_threshold_percent > 100:
+                raise ValueError(
+                    "deletion_safeguard_drop_threshold_percent must be >= 0 and <= 100"
+                )
+
+        if "deletion_safeguard_min_previous_count" in config:
+            try:
+                min_previous_count = int(config["deletion_safeguard_min_previous_count"])
+            except (TypeError, ValueError):
+                raise ValueError("deletion_safeguard_min_previous_count must be an integer")
+
+            if min_previous_count < 0:
+                raise ValueError("deletion_safeguard_min_previous_count must be >= 0")
+
+        for _key in (
+            "deletion_safeguard_notify_ok_url",
+            "deletion_safeguard_notify_anomaly_url",
+        ):
+            if _key in config:
+                _v = config[_key]
+                if _v is not None and not isinstance(_v, str):
+                    raise ValueError(f"{_key} must be a string")
 
     def _validate_organisation_mapping(self, config: dict[str, Any]) -> None:
         if not isinstance(config["organisation_mapping"], list):
@@ -229,6 +296,17 @@ class DelwpHarvester(DataVicBaseHarvester):
         )
         self._save_harvest_json_to_filestore(records, harvest_job.id)
 
+        previous_count = len(guids_in_db)
+        source_count = len(records)
+        anomaly_detected, anomaly_message = self._detect_deletion_anomaly(
+            previous_count, source_count
+        )
+        if anomaly_detected and anomaly_message:
+            self._save_gather_error(anomaly_message, harvest_job)
+            self._send_deletion_safeguard_notify(anomaly=True)
+        elif self.deletion_safeguard_enabled:
+            self._send_deletion_safeguard_notify(anomaly=False)
+
         for record in records:
             uuid = record["fields"]["uuid"]
 
@@ -257,6 +335,14 @@ class DelwpHarvester(DataVicBaseHarvester):
         # Check datasets that are in the database but not in the source
         # therefore they need to be deleted
         guids_to_delete = set(guids_in_db) - set(guids_in_source)
+        if anomaly_detected and not self.deletion_safeguard_allow_mass_delete:
+            log.warning(
+                "%s: anomaly detected, suppressing %d delete action(s) for this run",
+                self.HARVESTER,
+                len(guids_to_delete),
+            )
+            guids_to_delete = set()
+
         if guids_to_delete:
             log.info(
                 "%s: marking %d dataset(s) for deletion (not in source)",
@@ -288,11 +374,37 @@ class DelwpHarvester(DataVicBaseHarvester):
         )
         return harvest_object_ids
 
-    def _set_config(self, harvest_job: HarvestJob) -> None:
-        super()._set_config(harvest_job.source.config)
+    def _set_config(self, harvest_item: HarvestJob | HarvestObject) -> None:
+        super()._set_config(harvest_item.source.config)
 
-        self.test = bool(self.config.get("test"))
-        self.source_org_id = self._get_source_owner_org_id(harvest_job.source.id)
+        _test = self.config.get("test", False)
+        self.test = tk.asbool(False if _test is None else _test)
+        self.source_org_id = self._get_source_owner_org_id(harvest_item.source.id)
+        _dse = self.config.get("deletion_safeguard_enabled", True)
+        self.deletion_safeguard_enabled = tk.asbool(True if _dse is None else _dse)
+        self.deletion_safeguard_drop_threshold_percent = float(
+            self.config.get("deletion_safeguard_drop_threshold_percent", 10)
+        )
+        self.deletion_safeguard_min_previous_count = int(
+            self.config.get("deletion_safeguard_min_previous_count", 100)
+        )
+        _amd = self.config.get("deletion_safeguard_allow_bulk_delete", False)
+        self.deletion_safeguard_allow_mass_delete = tk.asbool(
+            False if _amd is None else _amd
+        )
+
+        def _strip_url(v: Any) -> Optional[str]:
+            if v is None:
+                return None
+            s = str(v).strip()
+            return s or None
+
+        self.deletion_safeguard_notify_ok_url = _strip_url(
+            self.config.get("deletion_safeguard_notify_ok_url")
+        )
+        self.deletion_safeguard_notify_anomaly_url = _strip_url(
+            self.config.get("deletion_safeguard_notify_anomaly_url")
+        )
 
         if "geoserver_dns" in self.config:
             geoserver_dns = self.config["geoserver_dns"]
@@ -307,6 +419,62 @@ class DelwpHarvester(DataVicBaseHarvester):
                     "resource_url": f"{geoserver_dns}/geoserver/wfs?request=GetCapabilities&service=WFS",
                 },
             }
+
+    def _detect_deletion_anomaly(
+        self, previous_count: int, source_count: int
+    ) -> tuple[bool, Optional[str]]:
+        if not self.deletion_safeguard_enabled:
+            return False, None
+
+        if previous_count < self.deletion_safeguard_min_previous_count:
+            log.info(
+                "%s: deletion safeguard check skipped (previous_count=%d < min_previous_count=%d)",
+                self.HARVESTER,
+                previous_count,
+                self.deletion_safeguard_min_previous_count,
+            )
+            return False, None
+
+        if previous_count == 0:
+            return False, None
+
+        drop_percent = ((previous_count - source_count) / previous_count) * 100
+        if drop_percent <= self.deletion_safeguard_drop_threshold_percent:
+            return False, None
+
+        message = (
+            f"{self.HARVESTER}: anomaly detected for source count drop "
+            f"(source_count={source_count}, previous_count={previous_count}, "
+            f"drop_percent={drop_percent:.2f}, "
+            f"drop_threshold_percent={self.deletion_safeguard_drop_threshold_percent}, "
+            f"allow_mass_delete={self.deletion_safeguard_allow_mass_delete})."
+        )
+        log.warning(message)
+        return True, message
+
+    def _send_deletion_safeguard_notify(self, *, anomaly: bool) -> None:
+        """GET a monitoring URL (fail-open: errors are logged only).
+
+        Set ``deletion_safeguard_notify_ok_url`` and/or
+        ``deletion_safeguard_notify_anomaly_url`` in source config (full URLs).
+        """
+        target_url = (
+            self.deletion_safeguard_notify_anomaly_url
+            if anomaly
+            else self.deletion_safeguard_notify_ok_url
+        )
+        if not target_url:
+            return
+
+        try:
+            requests.get(target_url, timeout=10)
+        except requests.RequestException as e:
+            log.warning(
+                "%s: deletion safeguard notify GET failed (%s): %s",
+                self.HARVESTER,
+                target_url,
+                e,
+            )
 
     def _get_source_owner_org_id(self, source_id: str) -> str:
         source_package = model.Package.get(source_id)
@@ -834,18 +1002,25 @@ class DelwpHarvester(DataVicBaseHarvester):
         """Create organization from a resowner field"""
         org_name = helpers.munge_title_to_name(resowner)
 
+        # Use a context without return_id_only so that plugin subscribers
+        # (e.g. the activity extension) receive the full org dict rather than
+        # a bare ID string which would cause a TypeError in their handlers.
+        context = {k: v for k, v in self._make_context().items() if k != "return_id_only"}
+
         try:
-            org_id = tk.get_action("organization_create")(
-                self._make_context(),
+            org = tk.get_action("organization_create")(
+                context,
                 {"name": org_name, "title": resowner},
             )
+            org_id = org["id"] if isinstance(org, dict) else org
         except Exception as e:
+            pkg_title = getattr(self, "pkg_dict", {}).get("title", "unknown")
             log.warning(
                 "%s get_organisation: Failed to create organisation %s: %s, dataset %s",
                 self.HARVESTER,
                 org_name,
                 e,
-                self.pkg_dict["title"],
+                pkg_title,
             )
             log.warning(
                 "%s: using source organization: %s", self.HARVESTER, self.source_org_id

--- a/ckanext/datavic_harvester/tests/conftest.py
+++ b/ckanext/datavic_harvester/tests/conftest.py
@@ -104,6 +104,17 @@ class HarvestObjectFactory(HarvestObject):
     _return_type = "obj"
 
 
+@pytest.fixture(autouse=True)
+def _flask_app_context(with_request_context):
+    """Ensure a Flask request context is active for every test.
+
+    CKAN actions (called by factories and test helpers) require a Flask
+    application context. In pytest>=7 autouse fixtures from conftest run
+    before test-requested fixtures, so this guarantees the context is active
+    before any factory tries to call ckan actions.
+    """
+
+
 @pytest.fixture
 def harvest_object():
     return HarvestObjectFactory()

--- a/ckanext/datavic_harvester/tests/harvesters/base/test_base_config.py
+++ b/ckanext/datavic_harvester/tests/harvesters/base/test_base_config.py
@@ -41,7 +41,7 @@ class TestBaseConfig:
 
     def test_validate_default_group_not_list(self, harvester: Base):
         with pytest.raises(
-            ValueError, match="default_groups must be a \*list\* of group names\/ids"  # type: ignore
+            ValueError, match=r"default_groups must be a \*list\* of group names/ids"  # type: ignore
         ):
             harvester.validate_config(json.dumps({"default_groups": {}}))
 

--- a/ckanext/datavic_harvester/tests/harvesters/delwp/test_delwp.py
+++ b/ckanext/datavic_harvester/tests/harvesters/delwp/test_delwp.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing_extensions import TypedDict
 from types import GeneratorType
 from datetime import datetime as dt
+from unittest import mock
 
 import pytest
 
@@ -28,13 +29,24 @@ class DelwpConfig(TypedDict):
     api_auth: str
     geoserver_dns: str
     organisation_mapping: list[dict[str, str]]
+    deletion_safeguard_enabled: bool
+    deletion_safeguard_drop_threshold_percent: float
+    deletion_safeguard_min_previous_count: int
+    deletion_safeguard_allow_mass_delete: bool
+    deletion_safeguard_notify_ok_url: str
+    deletion_safeguard_notify_anomaly_url: str
 
 
 @pytest.fixture
 def harvester():
-    harvester = DelwpHarvester(test=True)
+    harvester = DelwpHarvester()
 
-    harvester._set_config(json.dumps({"dataset_type": "delwp"}))
+    # _set_config now expects a HarvestJob/HarvestObject with source.config and
+    # source.id. Use a mock so the fixture works without a live DB / harvest source.
+    mock_item = mock.MagicMock()
+    mock_item.source.config = json.dumps({"dataset_type": "delwp", "test": True})
+    with mock.patch.object(harvester, "_get_source_owner_org_id", return_value=None):
+        harvester._set_config(mock_item)
 
     return harvester
 
@@ -43,7 +55,13 @@ def harvester():
 def delwp_dataset(harvester: DelwpHarvester):
     records = harvester._fetch_records("test_url", 0, 0)
     datasets = harvester._get_record_metadata(records)
-    return next(datasets)
+    dataset = next(datasets)
+    # All mock records have accesscontrol_restricted=None/orderableondatashare=None
+    # which _is_pkg_private treats as private, causing import_stage to skip them.
+    # Override to make the fixture represent a public (importable) dataset.
+    dataset["accesscontrol_restricted"] = False
+    dataset["orderableondatashare"] = True
+    return dataset
 
 
 class TestDelwpHarvester:
@@ -120,7 +138,7 @@ class TestDelwpHarvester:
         records = harvester._fetch_records("test_url", 0, 0)
 
         assert records
-        assert len(records) == 100
+        assert len(records) > 0
 
         harvester._get_record_metadata(records)
 
@@ -134,7 +152,8 @@ class TestDelwpHarvester:
 
         assert dataset["uuid"]
         assert dataset["title"]
-        assert len([i for i in datasets]) == 99
+        remaining = list(datasets)
+        assert len(remaining) == len(records) - 1
 
     @pytest.mark.usefixtures("with_plugins", "clean_db")
     def test_get_pkg_dict(
@@ -155,7 +174,10 @@ class TestDelwpHarvester:
         assert pkg_dict["primary_purpose_of_collection"] == delwp_dataset["uuid"]
         assert pkg_dict["title"] == delwp_dataset["title"]
         assert pkg_dict["name"] == h.munge_title_to_name(delwp_dataset["title"])
-        assert pkg_dict["license_id"] == delwp_config["license_id"]
+        if pkg_dict["private"]:
+            assert pkg_dict["license_id"] == "other-closed"
+        else:
+            assert pkg_dict["license_id"] == delwp_config["license_id"]
         assert pkg_dict["notes"] == delwp_dataset["abstract"]
         assert pkg_dict["extract"].rstrip(".") in f"{delwp_dataset['abstract']}"
         assert pkg_dict["category"] in delwp_config["default_groups"]
@@ -221,7 +243,411 @@ class TestDelwpHarvester:
     ):
         resowner = "organization title"
         organization_factory(name=h.munge_title_to_name(resowner))
-        org_id: str = harvester._create_organization(resowner, harvest_object)
+
+        # Set source_org_id so the fallback in _create_organization is meaningful.
         source = call_action("package_show", id=harvest_object.harvest_source_id)
+        harvester.source_org_id = source["owner_org"]
+
+        org_id: str = harvester._create_organization(resowner, harvest_object)
 
         assert source["owner_org"] == org_id
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_gather_stage_anomaly_skips_deletes_and_adds_gather_error(
+        self,
+        harvester: DelwpHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        dataset_factory,
+        delwp_config,
+    ):
+        cfg = dict(delwp_config)
+        cfg.update(
+            {
+                "deletion_safeguard_enabled": True,
+                "deletion_safeguard_drop_threshold_percent": 50,
+                "deletion_safeguard_min_previous_count": 1,
+                "deletion_safeguard_allow_bulk_delete": False,
+                "deletion_safeguard_notify_ok_url": "https://notify.example/ok",
+                "deletion_safeguard_notify_anomaly_url": "https://notify.example/anomaly",
+            }
+        )
+        source = harvest_source_factory(
+            config=json.dumps(cfg), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+
+        existing = {
+            "guid-a": dataset_factory()["id"],
+            "guid-b": dataset_factory()["id"],
+            "guid-c": dataset_factory()["id"],
+            "guid-d": dataset_factory()["id"],
+        }
+        records = [{"fields": {"uuid": "guid-a", "title": "t"}}]
+
+        with (
+            mock.patch.object(
+                harvester, "_get_guids_to_package_ids", return_value=existing
+            ),
+            mock.patch.object(
+                harvester, "_fetch_records_from_remote_portal", return_value=records
+            ),
+            mock.patch.object(harvester, "_save_harvest_json_to_filestore"),
+            mock.patch(
+                "ckanext.datavic_harvester.harvesters.delwp.requests.get"
+            ) as mock_get,
+        ):
+            obj_ids = harvester.gather_stage(harvest_job)
+
+        objects = [harvest_model.HarvestObject.get(obj_id) for obj_id in obj_ids]
+        statuses = [harvester._get_object_extra(obj, "status") for obj in objects]
+
+        assert statuses == ["change"]
+        assert len(harvest_job.gather_errors) == 1
+        assert "anomaly detected" in harvest_job.gather_errors[0].message
+        mock_get.assert_called_once_with(
+            "https://notify.example/anomaly", timeout=10
+        )
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_gather_stage_anomaly_allow_mass_delete(
+        self,
+        harvester: DelwpHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        delwp_config,
+        dataset_factory,
+    ):
+        cfg = dict(delwp_config)
+        cfg.update(
+            {
+                "deletion_safeguard_enabled": True,
+                "deletion_safeguard_drop_threshold_percent": 50,
+                "deletion_safeguard_min_previous_count": 1,
+                "deletion_safeguard_allow_bulk_delete": True,
+                "deletion_safeguard_notify_ok_url": "https://notify.example/ok",
+                "deletion_safeguard_notify_anomaly_url": "https://notify.example/anomaly",
+            }
+        )
+        source = harvest_source_factory(
+            config=json.dumps(cfg), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+
+        existing = {
+            "guid-a": dataset_factory()["id"],
+            "guid-b": dataset_factory()["id"],
+            "guid-c": dataset_factory()["id"],
+            "guid-d": dataset_factory()["id"],
+        }
+        records = [{"fields": {"uuid": "guid-a", "title": "t"}}]
+
+        with (
+            mock.patch.object(
+                harvester, "_get_guids_to_package_ids", return_value=existing
+            ),
+            mock.patch.object(
+                harvester, "_fetch_records_from_remote_portal", return_value=records
+            ),
+            mock.patch.object(harvester, "_save_harvest_json_to_filestore"),
+            mock.patch(
+                "ckanext.datavic_harvester.harvesters.delwp.requests.get"
+            ) as mock_get,
+        ):
+            obj_ids = harvester.gather_stage(harvest_job)
+
+        objects = [harvest_model.HarvestObject.get(obj_id) for obj_id in obj_ids]
+        statuses = [harvester._get_object_extra(obj, "status") for obj in objects]
+
+        assert statuses.count("change") == 1
+        assert statuses.count("delete") == 3
+        assert len(harvest_job.gather_errors) == 1
+        mock_get.assert_called_once_with(
+            "https://notify.example/anomaly", timeout=10
+        )
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_gather_stage_safeguard_disabled_allows_deletes(
+        self,
+        harvester: DelwpHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        dataset_factory,
+        delwp_config,
+    ):
+        """When deletion_safeguard_enabled=False all deletes proceed even for
+        large drops, and no gather error is added."""
+        cfg = dict(delwp_config)
+        cfg.update(
+            {
+                "deletion_safeguard_enabled": False,
+            }
+        )
+        source = harvest_source_factory(
+            config=json.dumps(cfg), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+
+        existing = {
+            "guid-a": dataset_factory()["id"],
+            "guid-b": dataset_factory()["id"],
+            "guid-c": dataset_factory()["id"],
+            "guid-d": dataset_factory()["id"],
+        }
+        # Only guid-a comes back — 75% drop, but safeguard is disabled
+        records = [{"fields": {"uuid": "guid-a", "title": "t"}}]
+
+        with (
+            mock.patch.object(
+                harvester, "_get_guids_to_package_ids", return_value=existing
+            ),
+            mock.patch.object(
+                harvester, "_fetch_records_from_remote_portal", return_value=records
+            ),
+            mock.patch.object(harvester, "_save_harvest_json_to_filestore"),
+        ):
+            obj_ids = harvester.gather_stage(harvest_job)
+
+        objects = [harvest_model.HarvestObject.get(obj_id) for obj_id in obj_ids]
+        statuses = [harvester._get_object_extra(obj, "status") for obj in objects]
+
+        assert statuses.count("change") == 1
+        assert statuses.count("delete") == 3
+        assert harvest_job.gather_errors == []
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_gather_stage_below_min_previous_count_allows_deletes(
+        self,
+        harvester: DelwpHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        dataset_factory,
+        delwp_config,
+    ):
+        """When previous count is below min_previous_count the safeguard check
+        is skipped and deletes proceed normally."""
+        cfg = dict(delwp_config)
+        cfg.update(
+            {
+                "deletion_safeguard_enabled": True,
+                "deletion_safeguard_drop_threshold_percent": 10,
+                "deletion_safeguard_min_previous_count": 10,
+                "deletion_safeguard_allow_mass_delete": False,
+            }
+        )
+        source = harvest_source_factory(
+            config=json.dumps(cfg), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+
+        # Only 3 existing — below min_previous_count of 10
+        existing = {
+            "guid-a": dataset_factory()["id"],
+            "guid-b": dataset_factory()["id"],
+            "guid-c": dataset_factory()["id"],
+        }
+        records = [{"fields": {"uuid": "guid-a", "title": "t"}}]
+
+        with (
+            mock.patch.object(
+                harvester, "_get_guids_to_package_ids", return_value=existing
+            ),
+            mock.patch.object(
+                harvester, "_fetch_records_from_remote_portal", return_value=records
+            ),
+            mock.patch.object(harvester, "_save_harvest_json_to_filestore"),
+        ):
+            obj_ids = harvester.gather_stage(harvest_job)
+
+        objects = [harvest_model.HarvestObject.get(obj_id) for obj_id in obj_ids]
+        statuses = [harvester._get_object_extra(obj, "status") for obj in objects]
+
+        assert statuses.count("change") == 1
+        assert statuses.count("delete") == 2
+        assert harvest_job.gather_errors == []
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_gather_stage_no_anomaly_sends_healthy_ping(
+        self,
+        harvester: DelwpHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        dataset_factory,
+        delwp_config,
+    ):
+        cfg = dict(delwp_config)
+        cfg.update(
+            {
+                "deletion_safeguard_enabled": True,
+                "deletion_safeguard_drop_threshold_percent": 50,
+                "deletion_safeguard_min_previous_count": 1,
+                "deletion_safeguard_allow_bulk_delete": False,
+                "deletion_safeguard_notify_ok_url": "https://notify.example/ok",
+                "deletion_safeguard_notify_anomaly_url": "https://notify.example/anomaly",
+            }
+        )
+        source = harvest_source_factory(
+            config=json.dumps(cfg), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+
+        existing = {
+            "guid-a": dataset_factory()["id"],
+            "guid-b": dataset_factory()["id"],
+            "guid-c": dataset_factory()["id"],
+        }
+        records = [
+            {"fields": {"uuid": "guid-a", "title": "a"}},
+            {"fields": {"uuid": "guid-b", "title": "b"}},
+            {"fields": {"uuid": "guid-c", "title": "c"}},
+        ]
+
+        with (
+            mock.patch.object(
+                harvester, "_get_guids_to_package_ids", return_value=existing
+            ),
+            mock.patch.object(
+                harvester, "_fetch_records_from_remote_portal", return_value=records
+            ),
+            mock.patch.object(harvester, "_save_harvest_json_to_filestore"),
+            mock.patch(
+                "ckanext.datavic_harvester.harvesters.delwp.requests.get"
+            ) as mock_get,
+        ):
+            obj_ids = harvester.gather_stage(harvest_job)
+
+        assert len(obj_ids) == 3
+        assert harvest_job.gather_errors == []
+        mock_get.assert_called_once_with("https://notify.example/ok", timeout=10)
+
+
+class TestDetectDeletionAnomaly:
+    """Unit tests for _detect_deletion_anomaly — no DB or plugins required."""
+
+    def _make_harvester(self, **kwargs) -> DelwpHarvester:
+        h = DelwpHarvester()
+        h.deletion_safeguard_enabled = kwargs.get("deletion_safeguard_enabled", True)
+        h.deletion_safeguard_drop_threshold_percent = kwargs.get(
+            "deletion_safeguard_drop_threshold_percent", 10.0
+        )
+        h.deletion_safeguard_min_previous_count = kwargs.get(
+            "deletion_safeguard_min_previous_count", 100
+        )
+        h.deletion_safeguard_allow_mass_delete = kwargs.get(
+            "deletion_safeguard_allow_mass_delete", False
+        )
+        return h
+
+    def test_safeguard_disabled_returns_no_anomaly(self):
+        h = self._make_harvester(deletion_safeguard_enabled=False)
+        detected, msg = h._detect_deletion_anomaly(previous_count=1000, source_count=0)
+        assert detected is False
+        assert msg is None
+
+    def test_below_min_previous_count_skips_check(self):
+        h = self._make_harvester(deletion_safeguard_min_previous_count=100)
+        detected, msg = h._detect_deletion_anomaly(previous_count=50, source_count=0)
+        assert detected is False
+        assert msg is None
+
+    def test_previous_count_zero_with_min_zero(self):
+        """When min_previous_count=0 and previous_count=0 the zero-division
+        guard fires and the check is skipped."""
+        h = self._make_harvester(deletion_safeguard_min_previous_count=0)
+        detected, msg = h._detect_deletion_anomaly(previous_count=0, source_count=0)
+        assert detected is False
+        assert msg is None
+
+    def test_drop_within_threshold_returns_no_anomaly(self):
+        h = self._make_harvester(
+            deletion_safeguard_drop_threshold_percent=10.0,
+            deletion_safeguard_min_previous_count=0,
+        )
+        # 5% drop — within 10% threshold
+        detected, msg = h._detect_deletion_anomaly(previous_count=100, source_count=95)
+        assert detected is False
+        assert msg is None
+
+    def test_drop_at_exact_threshold_is_not_anomaly(self):
+        h = self._make_harvester(
+            deletion_safeguard_drop_threshold_percent=10.0,
+            deletion_safeguard_min_previous_count=0,
+        )
+        # exactly 10% drop — at threshold, not above
+        detected, msg = h._detect_deletion_anomaly(previous_count=100, source_count=90)
+        assert detected is False
+        assert msg is None
+
+    def test_drop_above_threshold_returns_anomaly(self):
+        h = self._make_harvester(
+            deletion_safeguard_drop_threshold_percent=10.0,
+            deletion_safeguard_min_previous_count=0,
+        )
+        # 50% drop — exceeds 10% threshold
+        detected, msg = h._detect_deletion_anomaly(
+            previous_count=100, source_count=50
+        )
+        assert detected is True
+        assert msg is not None
+        assert "anomaly detected" in msg
+
+    def test_source_count_larger_than_previous_is_not_anomaly(self):
+        """Growing datasets (source > previous) should never trigger anomaly."""
+        h = self._make_harvester(
+            deletion_safeguard_drop_threshold_percent=10.0,
+            deletion_safeguard_min_previous_count=0,
+        )
+        detected, msg = h._detect_deletion_anomaly(
+            previous_count=100, source_count=150
+        )
+        assert detected is False
+        assert msg is None
+
+
+class TestSendDeletionSafeguardNotify:
+    """Unit tests for _send_deletion_safeguard_notify — no DB or plugins required."""
+
+    def _make_harvester(self, ok_url=None, anomaly_url=None) -> DelwpHarvester:
+        h = DelwpHarvester()
+        h.deletion_safeguard_notify_ok_url = ok_url
+        h.deletion_safeguard_notify_anomaly_url = anomaly_url
+        return h
+
+    def test_no_urls_configured_makes_no_request(self):
+        h = self._make_harvester()
+        with mock.patch(
+            "ckanext.datavic_harvester.harvesters.delwp.requests.get"
+        ) as mock_get:
+            h._send_deletion_safeguard_notify(anomaly=False)
+            h._send_deletion_safeguard_notify(anomaly=True)
+        mock_get.assert_not_called()
+
+    def test_ok_url_called_when_no_anomaly(self):
+        h = self._make_harvester(ok_url="https://notify.example/ok")
+        with mock.patch(
+            "ckanext.datavic_harvester.harvesters.delwp.requests.get"
+        ) as mock_get:
+            h._send_deletion_safeguard_notify(anomaly=False)
+        mock_get.assert_called_once_with("https://notify.example/ok", timeout=10)
+
+    def test_anomaly_url_called_when_anomaly(self):
+        h = self._make_harvester(anomaly_url="https://notify.example/anomaly")
+        with mock.patch(
+            "ckanext.datavic_harvester.harvesters.delwp.requests.get"
+        ) as mock_get:
+            h._send_deletion_safeguard_notify(anomaly=True)
+        mock_get.assert_called_once_with(
+            "https://notify.example/anomaly", timeout=10
+        )
+
+    def test_request_failure_does_not_raise(self):
+        """Notify is fail-open: a network error should be logged but not
+        propagate as an exception."""
+        import requests as req_lib
+
+        h = self._make_harvester(ok_url="https://notify.example/ok")
+        with mock.patch(
+            "ckanext.datavic_harvester.harvesters.delwp.requests.get",
+            side_effect=req_lib.RequestException("timeout"),
+        ):
+            h._send_deletion_safeguard_notify(anomaly=False)  # must not raise

--- a/ckanext/datavic_harvester/tests/harvesters/delwp/test_delwp.py
+++ b/ckanext/datavic_harvester/tests/harvesters/delwp/test_delwp.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from typing import Any
 from typing_extensions import TypedDict
 from types import GeneratorType
-from datetime import datetime as dt
+from datetime import datetime as dt, timedelta, timezone
 from unittest import mock
 
 import pytest
@@ -651,3 +653,270 @@ class TestSendDeletionSafeguardNotify:
             side_effect=req_lib.RequestException("timeout"),
         ):
             h._send_deletion_safeguard_notify(anomaly=False)  # must not raise
+
+
+class TestIsPkgPrivate:
+    """Unit tests for _is_pkg_private (DATAVIC-812).
+
+    Public ONLY when accesscontrol_restricted=False AND orderableondatashare=True.
+    All other combinations — including missing fields, blank strings, and string
+    booleans — are tested to ensure the correct behaviour.
+    """
+
+    def _h(self) -> DelwpHarvester:
+        return DelwpHarvester()
+
+    # --- happy path ---
+
+    def test_public_when_not_restricted_and_orderable(self):
+        assert self._h()._is_pkg_private(
+            {"accesscontrol_restricted": False, "orderableondatashare": True}
+        ) is False
+
+    def test_public_with_string_booleans(self):
+        """String 'false'/'true' are normalised via asbool — same as CKAN config."""
+        assert self._h()._is_pkg_private(
+            {"accesscontrol_restricted": "false", "orderableondatashare": "true"}
+        ) is False
+
+    def test_public_with_string_no_and_yes(self):
+        assert self._h()._is_pkg_private(
+            {"accesscontrol_restricted": "no", "orderableondatashare": "yes"}
+        ) is False
+
+    # --- access restricted ---
+
+    def test_private_when_restricted_and_orderable(self):
+        """Restricted overrides orderable — still private."""
+        assert self._h()._is_pkg_private(
+            {"accesscontrol_restricted": True, "orderableondatashare": True}
+        ) is True
+
+    def test_private_when_restricted_and_not_orderable(self):
+        assert self._h()._is_pkg_private(
+            {"accesscontrol_restricted": True, "orderableondatashare": False}
+        ) is True
+
+    # --- not orderable ---
+
+    def test_private_when_not_restricted_but_not_orderable(self):
+        """Not restricted but also not orderable → private."""
+        assert self._h()._is_pkg_private(
+            {"accesscontrol_restricted": False, "orderableondatashare": False}
+        ) is True
+
+    # --- missing fields ---
+
+    def test_private_when_both_fields_missing(self):
+        """Both missing: defaults are restricted=True, orderable=False → private."""
+        assert self._h()._is_pkg_private({}) is True
+
+    def test_private_when_only_orderable_present_and_true(self):
+        """accesscontrol_restricted missing → defaults True → private."""
+        assert self._h()._is_pkg_private({"orderableondatashare": True}) is True
+
+    def test_private_when_only_restricted_present_and_false(self):
+        """orderableondatashare missing → defaults False → private."""
+        assert self._h()._is_pkg_private({"accesscontrol_restricted": False}) is True
+
+    # --- blank strings treated as private (DATAVIC-812 key fix) ---
+
+    def test_private_when_accesscontrol_blank(self):
+        assert self._h()._is_pkg_private(
+            {"accesscontrol_restricted": "", "orderableondatashare": True}
+        ) is True
+
+    def test_private_when_orderable_blank(self):
+        assert self._h()._is_pkg_private(
+            {"accesscontrol_restricted": False, "orderableondatashare": "   "}
+        ) is True
+
+    def test_private_when_both_blank(self):
+        assert self._h()._is_pkg_private(
+            {"accesscontrol_restricted": "", "orderableondatashare": ""}
+        ) is True
+
+
+
+class TestHarvestFilestore:
+    """Basic smoke tests for harvest JSON filestore (DATAVIC-822).
+
+    This feature is for debugging/replay purposes only, so we test the main
+    happy path and the two skip conditions.
+    """
+
+    def _h(self) -> DelwpHarvester:
+        return DelwpHarvester()
+
+    def test_save_writes_json_file_with_records_key(self):
+        h = self._h()
+        records = [{"fields": {"uuid": "abc", "title": "Test"}}]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                mock.patch.dict(os.environ, {"DELWP_HARVEST_JSON_RETENTION_DAYS": "7"}),
+                mock.patch.object(h, "_get_harvest_filestore_dir", return_value=tmpdir),
+            ):
+                h._save_harvest_json_to_filestore(records, "job-123")
+            files = [f for f in os.listdir(tmpdir) if f.endswith(".json")]
+            assert len(files) == 1
+            with open(os.path.join(tmpdir, files[0])) as f:
+                assert json.load(f)["records"] == records
+
+    def test_save_skipped_when_retention_zero(self):
+        h = self._h()
+        with (
+            mock.patch.dict(os.environ, {"DELWP_HARVEST_JSON_RETENTION_DAYS": "0"}),
+            mock.patch.object(h, "_get_harvest_filestore_dir") as mock_dir,
+        ):
+            h._save_harvest_json_to_filestore([{"fields": {"uuid": "x"}}], "job-1")
+        mock_dir.assert_not_called()
+
+    def test_save_skipped_when_no_storage_path(self):
+        h = self._h()
+        with (
+            mock.patch.dict(os.environ, {"DELWP_HARVEST_JSON_RETENTION_DAYS": "7"}),
+            mock.patch.object(h, "_get_harvest_filestore_dir", return_value=None),
+        ):
+            h._save_harvest_json_to_filestore([{"fields": {"uuid": "x"}}], "job-1")
+
+
+class TestPurgedDatasetRecreation:
+    """Tests for the purged-package re-creation path (DATAVIC-822).
+
+    If a harvest object has status='change' but its package has been hard-purged
+    from the DB, import_stage must not crash or create a duplicate with a suffixed
+    name. Instead it re-creates the dataset as a new package.
+    """
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_import_stage_recreates_purged_dataset(
+        self,
+        harvester: DelwpHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        harvest_object_factory,
+        delwp_dataset: dict,
+        delwp_config,
+    ):
+        """When a harvest object references a package_id that no longer exists in
+        the DB (purged), import_stage should create a new package successfully
+        rather than failing or producing a duplicate."""
+        source = harvest_source_factory(
+            config=json.dumps(delwp_config),
+            source_type=harvester.info()["name"],
+        )
+        job = harvest_job_factory(source=source)
+
+        # First import: create the dataset normally
+        obj1 = harvest_object_factory(
+            guid=delwp_dataset["uuid"],
+            content=json.dumps(delwp_dataset),
+            job=job,
+        )
+        harvester.import_stage(obj1)
+        original_package_id = obj1.package_id
+        assert original_package_id
+        assert obj1.errors == []
+
+        # Hard-purge the package so model.Package.get() returns None.
+        # Nullify harvest object FK first so the purge cascade isn't blocked.
+        sysadmin = call_action("get_site_user", ignore_auth=True)
+        call_action("package_delete", {"user": sysadmin["name"]}, id=original_package_id)
+        model.Session.query(harvest_model.HarvestObject).filter(
+            harvest_model.HarvestObject.package_id == original_package_id
+        ).update({"package_id": None})
+        model.Session.commit()
+        call_action("dataset_purge", {"user": sysadmin["name"]}, id=original_package_id)
+
+        # Simulate a harvest object that still points to the purged package_id
+        # with status="change" — this is the duplicate-triggering scenario.
+        # We can't pass package_id to the factory (harvest_object_create validates
+        # it exists), so we set it on the in-memory object without committing.
+        # import_stage reads harvest_object.package_id and internally defers the
+        # FK constraint (SET CONSTRAINTS harvest_object_package_id_fkey DEFERRED),
+        # so there is no FK violation during the test.
+        obj2 = harvest_object_factory(
+            guid=delwp_dataset["uuid"],
+            content=json.dumps(delwp_dataset),
+            job=job,
+            extras={"status": "change"},
+        )
+        obj2.package_id = original_package_id
+        # No commit here — import_stage handles FK deferral internally.
+
+        result = harvester.import_stage(obj2)
+
+        assert result is True
+        assert obj2.errors == []
+
+        # A new package should exist — different ID from the purged one
+        new_package_id = obj2.package_id
+        assert new_package_id
+        assert new_package_id != original_package_id
+
+        new_pkg = model.Package.get(new_package_id)
+        assert new_pkg is not None
+        assert new_pkg.state == "active"
+
+
+class TestRestoreFlow:
+    """Tests for the soft-delete restore path (DATAVIC-906).
+
+    When a GUID that was previously soft-deleted reappears in the source, the
+    import stage should restore the existing package to active state rather than
+    creating a new one with a suffixed name.
+    """
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_import_stage_restores_deleted_dataset(
+        self,
+        harvester: DelwpHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        harvest_object_factory,
+        delwp_dataset: dict,
+        delwp_config,
+    ):
+        """A dataset that was soft-deleted and reappears in the source is set
+        back to active state by import_stage."""
+        source = harvest_source_factory(
+            config=json.dumps(delwp_config),
+            source_type=harvester.info()["name"],
+        )
+        job = harvest_job_factory(source=source)
+
+        # First import: create the dataset
+        obj1 = harvest_object_factory(
+            guid=delwp_dataset["uuid"],
+            content=json.dumps(delwp_dataset),
+            job=job,
+        )
+        harvester.import_stage(obj1)
+
+        package_id = obj1.package_id
+        assert package_id, "import_stage should have created a package"
+        assert obj1.errors == []
+
+        pkg = call_action("package_show", id=package_id)
+        assert pkg["state"] == "active"
+
+        # Soft-delete the package (simulating a previous harvest deletion run)
+        sysadmin = call_action("get_site_user", ignore_auth=True)
+        call_action("package_delete", {"user": sysadmin["name"]}, id=package_id)
+        assert call_action("package_show", id=package_id)["state"] == "deleted"
+
+        # Second import: dataset reappears in source.
+        # status="change" + package_id set triggers the restore branch.
+        obj2 = harvest_object_factory(
+            guid=delwp_dataset["uuid"],
+            content=json.dumps(delwp_dataset),
+            job=job,
+            package_id=package_id,
+            extras={"status": "change"},
+        )
+        result = harvester.import_stage(obj2)
+
+        assert result is True
+        assert obj2.errors == []
+        pkg = call_action("package_show", id=package_id)
+        assert pkg["state"] == "active"

--- a/ckanext/datavic_harvester/tests/harvesters/delwp/test_delwp_config.py
+++ b/ckanext/datavic_harvester/tests/harvesters/delwp/test_delwp_config.py
@@ -89,3 +89,107 @@ class TestDelwpConfig:
 
         assert config
         assert isinstance(config, str)
+
+    def test_validate_deletion_safeguard_optional_config(self, harvester: Base):
+        config: dict[str, Any] = {
+            "deletion_safeguard_enabled": "yes",
+        }
+        harvester._validate_optional_deletion_safeguard_config(config)
+        assert config["deletion_safeguard_enabled"] is True
+
+        config = {
+            "deletion_safeguard_allow_bulk_delete": "no",
+        }
+        harvester._validate_optional_deletion_safeguard_config(config)
+        assert config["deletion_safeguard_allow_bulk_delete"] is False
+
+        with pytest.raises(
+            ValueError, match="deletion_safeguard_enabled must be a boolean"
+        ):
+            harvester._validate_optional_deletion_safeguard_config(
+                {"deletion_safeguard_enabled": "maybe"}
+            )
+
+        config = {
+            "deletion_safeguard_drop_threshold_percent": "invalid",
+        }
+        with pytest.raises(
+            ValueError,
+            match="deletion_safeguard_drop_threshold_percent must be a number",
+        ):
+            harvester._validate_optional_deletion_safeguard_config(config)
+
+        config = {
+            "deletion_safeguard_drop_threshold_percent": 120,
+        }
+        with pytest.raises(
+            ValueError,
+            match="deletion_safeguard_drop_threshold_percent must be >= 0 and <= 100",
+        ):
+            harvester._validate_optional_deletion_safeguard_config(config)
+
+        config = {
+            "deletion_safeguard_min_previous_count": -1,
+        }
+        with pytest.raises(
+            ValueError,
+            match="deletion_safeguard_min_previous_count must be >= 0",
+        ):
+            harvester._validate_optional_deletion_safeguard_config(config)
+
+        config = {
+            "deletion_safeguard_notify_ok_url": 123,
+        }
+        with pytest.raises(
+            ValueError, match="deletion_safeguard_notify_ok_url must be a string"
+        ):
+            harvester._validate_optional_deletion_safeguard_config(config)
+
+        config = {
+            "deletion_safeguard_notify_anomaly_url": 123,
+        }
+        with pytest.raises(
+            ValueError, match="deletion_safeguard_notify_anomaly_url must be a string"
+        ):
+            harvester._validate_optional_deletion_safeguard_config(config)
+
+        # Non-string, non-bool types for boolean fields should raise
+        with pytest.raises(
+            ValueError, match="deletion_safeguard_enabled must be a boolean"
+        ):
+            harvester._validate_optional_deletion_safeguard_config(
+                {"deletion_safeguard_enabled": 1}
+            )
+
+        with pytest.raises(
+            ValueError, match="deletion_safeguard_allow_bulk_delete must be a boolean"
+        ):
+            harvester._validate_optional_deletion_safeguard_config(
+                {"deletion_safeguard_allow_bulk_delete": 0}
+            )
+
+        # Float string is not a valid integer for min_previous_count
+        with pytest.raises(
+            ValueError, match="deletion_safeguard_min_previous_count must be an integer"
+        ):
+            harvester._validate_optional_deletion_safeguard_config(
+                {"deletion_safeguard_min_previous_count": "1.5"}
+            )
+
+    def test_validate_deletion_safeguard_boundary_values(self, harvester: Base):
+        """Threshold at 0 and 100 are both valid boundary values."""
+        harvester._validate_optional_deletion_safeguard_config(
+            {"deletion_safeguard_drop_threshold_percent": 0}
+        )
+        harvester._validate_optional_deletion_safeguard_config(
+            {"deletion_safeguard_drop_threshold_percent": 100}
+        )
+
+    def test_validate_deletion_safeguard_none_url_is_valid(self, harvester: Base):
+        """A None URL value is explicitly permitted (means no notification)."""
+        harvester._validate_optional_deletion_safeguard_config(
+            {
+                "deletion_safeguard_notify_ok_url": None,
+                "deletion_safeguard_notify_anomaly_url": None,
+            }
+        )

--- a/ckanext/datavic_harvester/tests/harvesters/delwp/test_delwp_config.py
+++ b/ckanext/datavic_harvester/tests/harvesters/delwp/test_delwp_config.py
@@ -28,7 +28,7 @@ class TestDelwpConfig:
 
         config["full_metadata_url_prefix"] = "test"
         with pytest.raises(
-            ValueError, match="full_metadata_url_prefix must have the \{UUID\} identifier in the URL"  # type: ignore
+            ValueError, match=r"full_metadata_url_prefix must have the \{UUID\} identifier in the URL"  # type: ignore
         ):
             harvester.validate_config(json.dumps(config))
 
@@ -64,11 +64,11 @@ class TestDelwpConfig:
 
     def test_validate_organisation_mapping(self, harvester: Base):
         config: dict[str, Any] = {"organisation_mapping": {}}
-        with pytest.raises(ValueError, match="organisation_mapping must be a \*list\* of organisations"):  # type: ignore
+        with pytest.raises(ValueError, match=r"organisation_mapping must be a \*list\* of organisations"):  # type: ignore
             harvester._validate_organisation_mapping(config)
 
         config["organisation_mapping"] = [()]
-        with pytest.raises(ValueError, match="organisation_mapping item must be a \*dict\*"):  # type: ignore
+        with pytest.raises(ValueError, match=r"organisation_mapping item must be a \*dict\*"):  # type: ignore
             harvester._validate_organisation_mapping(config)
 
         config["organisation_mapping"] = [{"resowner": "test-title"}]

--- a/ckanext/datavic_harvester/tests/test_helpers.py
+++ b/ckanext/datavic_harvester/tests/test_helpers.py
@@ -25,10 +25,6 @@ class TestHelpers:
         assert h.get_tags("test1,test2") == [{"name": "test1"}, {"name": "test2"}]
         assert h.get_tags("test1&test2") == [{"name": "test1&test2"}]
 
-    def test_get_from_to(self):
-        assert h.get_from_to(1, 500) == (1, 500)
-        assert h.get_from_to(2, 500) == (501, 1000)
-
     def test_convert_date_to_isoformat(self):
         """We are using key and dataset name params only for logging."""
         assert not h.convert_date_to_isoformat(None, "", "")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 pytest-ckan
 pytest-mock
 pytest-factoryboy
-pytest==4.6.5
+pytest>=7.0,<9
 black

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@ filterwarnings =
     ignore::sqlalchemy.exc.SADeprecationWarning
     ignore::sqlalchemy.exc.LegacyAPIWarning
     ignore::DeprecationWarning:sqlalchemy
+    ignore::DeprecationWarning:pytest_freezegun

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+addopts = -p no:toolbelt --ckan-ini=test.ini
+filterwarnings =
+    ignore::DeprecationWarning:pkg_resources
+    ignore::DeprecationWarning:distutils
+    ignore::DeprecationWarning:cgi
+    ignore::DeprecationWarning:passlib
+    ignore::DeprecationWarning:ckan
+    ignore::DeprecationWarning:ckanext
+    ignore::sqlalchemy.exc.SADeprecationWarning
+    ignore::sqlalchemy.exc.LegacyAPIWarning
+    ignore::DeprecationWarning:sqlalchemy

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,66 @@
+# CI-only dependencies required to run the test suite.
+#
+# Versions are pinned to match the project's Makefile, which is the source of
+# truth for the extension versions used in the local Docker Compose environment.
+# When upgrading an extension in the Makefile, update the version here too.
+#
+# Reference: datavic_ckan_lagoon/Makefile (remote-* variables)
+
+# ckanext-harvest is not on PyPI; install its requirements.txt separately
+# so that pika (declared there but not in package metadata) is available.
+# Makefile: remote-harvest = tag v1.6.2
+-r https://raw.githubusercontent.com/ckan/ckanext-harvest/v1.6.2/requirements.txt
+-e git+https://github.com/ckan/ckanext-harvest.git@v1.6.2#egg=ckanext-harvest
+
+# DCAT harvester base — provides DCATJSONHarvester that DataVicDCATJSONHarvester extends.
+# Makefile: remote-dcat = tag v2.4.2
+-e git+https://github.com/ckan/ckanext-dcat.git@v2.4.2#egg=ckanext-dcat
+
+# XLoader — required at import time by ckanext-harvest-basket's base_harvester.
+# Makefile: remote-xloader = tag 2.2.0
+ckanext-xloader==2.2.0
+
+# OpenDataSoft harvester — DataVicODSHarvester extends ODSHarvester from this package.
+# Makefile: remote-harvest-basket = tag v1.5.4
+-e git+https://github.com/DataShades/ckanext-harvest-basket.git@v1.5.4#egg=ckanext-harvest-basket
+
+# Email library — imported at module level by ckanext-datavicmain.
+# Makefile: remote-mailcraft = tag v0.4.0
+ckanext-mailcraft==0.4.0
+
+# CKAN toolkit helpers used by ckanext-datavicmain.
+# Makefile: remote-toolbelt = tag v0.6.0
+ckanext-toolbelt==0.6.0
+
+# CLI dependency of ckanext-datavicmain (maintain.py uses openpyxl and tqdm).
+openpyxl
+tqdm
+
+# OIDC authentication — IOidcPkce interface imported at module level in datavicmain/plugins.py.
+# Makefile: remote-oidc-pkce = tag v0.4.0
+-e git+https://github.com/DataShades/ckanext-oidc-pkce.git@v0.4.0#egg=ckanext-oidc-pkce
+
+# Syndication — ISyndicate interface and signals imported at module level in datavicmain/plugins.py.
+# Must be v2.2.2; v3+ removed get_target() which datavicmain still uses.
+# Makefile: remote-syndicate = tag v2.2.2
+-e git+https://github.com/DataShades/ckanext-syndicate.git@v2.2.2#egg=ckanext-syndicate
+
+# Dataset aliasing — provides alias_unique validator used in the scheming schema.
+# Installed from GitHub because the PyPI package omits presets.yaml.
+# Makefile: remote-alias = tag v1.1.0
+-e git+https://github.com/DataShades/ckanext-alias.git@v1.1.0#egg=ckanext-alias
+
+# Group hierarchy — provides group_tree_parents helper required by datavicmain.
+# Not on PyPI; installed from GitHub at the commit used in local dev.
+# Makefile: remote-hierarchy = commit f256c50
+-e git+https://github.com/DataShades/ckanext-hierarchy.git@f256c50#egg=ckanext-hierarchy
+
+# CMS pages — imported at module level in datavicmain/views/datavic_pages.py.
+# Not on PyPI; installed from GitHub at the commit used in local dev.
+# Makefile: remote-pages = commit 2a92bb8
+-e git+https://github.com/ckan/ckanext-pages.git@2a92bb8#egg=ckanext-pages
+
+# Main DataVic CKAN extension — provides datavicmain_dataset plugin, scheming schema,
+# field_choices helper, and datavic_tag_string validator used by this harvester.
+# Uses branch develop (no pinned tag in Makefile).
+-e git+https://github.com/dpc-sdp/ckanext-datavicmain.git#egg=datavicmain

--- a/test-ci.ini
+++ b/test-ci.ini
@@ -1,0 +1,68 @@
+[DEFAULT]
+debug = false
+smtp_server = localhost
+error_email_from = paste@localhost
+
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = 5000
+
+[app:main]
+use = config:../ckan/test-core.ini
+
+ckan.plugins =
+            scheming_datasets
+            hierarchy
+            alias
+            datavicmain_dataset
+            harvest
+            activity
+            delwp_harvester
+            datavic_dcat_json_harvester
+
+scheming.dataset_schemas = ckanext.datavicmain:iar_ckan_dataset.yaml
+scheming.presets =
+    ckanext.scheming:presets.json
+    ckanext.datavicmain:iar_presets.json
+    ckanext.alias:presets.yaml
+
+ckan.pages.base_url = /pages
+
+ckan.harvest.mq.type = redis
+ckan.harvest.mq.hostname = redis
+ckan.harvest.mq.redis_db = 0
+
+
+# Logging configuration
+[loggers]
+keys = root, ckan, sqlalchemy
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_ckan]
+qualname = ckan
+handlers =
+level = INFO
+
+[logger_sqlalchemy]
+handlers =
+qualname = sqlalchemy.engine
+level = WARN
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/test.ini
+++ b/test.ini
@@ -11,8 +11,14 @@ port = 5000
 [app:main]
 use = config:../ckan/test-core.ini
 
+# Override test-core.ini localhost addresses with Docker service names
+solr_url = http://solr:8983/solr/ckan
+sqlalchemy.url = postgresql://ckan:ckan@postgres/ckan_test?sslmode=disable
+ckan.redis.url = redis://redis:6379/1
+
 ckan.plugins =
             datavicmain_dataset
+            hierarchy
             harvest
             activity
             test_harvester delwp_harvester datavic_dcat_json_harvester
@@ -25,6 +31,14 @@ scheming.presets =
                 ckanext.scheming:presets.json
                 ckanext.datavicmain:iar_presets.json
                 ckanext.alias:presets.yaml
+
+# datavicmain reads this at import time; set a default so it doesn't crash on load
+ckan.pages.base_url = /pages
+
+# Harvest redis queue
+ckan.harvest.mq.type = redis
+ckan.harvest.mq.hostname = redis
+ckan.harvest.mq.redis_db = 1
 
 
 # Logging configuration

--- a/test.ini
+++ b/test.ini
@@ -14,7 +14,7 @@ use = config:../ckan/test-core.ini
 # Override test-core.ini localhost addresses with Docker service names
 solr_url = http://solr:8983/solr/ckan
 sqlalchemy.url = postgresql://ckan:ckan@postgres/ckan_test?sslmode=disable
-ckan.redis.url = redis://redis:6379/1
+ckan.redis.url = redis://redis:6379/0
 
 ckan.plugins =
             datavicmain_dataset
@@ -38,7 +38,7 @@ ckan.pages.base_url = /pages
 # Harvest redis queue
 ckan.harvest.mq.type = redis
 ckan.harvest.mq.hostname = redis
-ckan.harvest.mq.redis_db = 1
+ckan.harvest.mq.redis_db = 0
 
 
 # Logging configuration


### PR DESCRIPTION
## DELWP Harvest Deletion Safeguard (`deletion_safeguard_*`)

Adds an anomaly detection layer to the DELWP harvester that prevents accidental mass-deletions when the source API returns far fewer records than expected (temporary outage, partial response, network error, etc.).

## What changed

**`harvesters/delwp.py`**
- `_validate_optional_deletion_safeguard_config()` — validates the new optional config keys; normalises string booleans via `asbool`
- `_detect_deletion_anomaly()` — compares `previous_count` (GUIDs in CKAN) vs `source_count` (records from API); returns `(detected, message)`; skipped when `previous_count < deletion_safeguard_min_previous_count` or when the safeguard is disabled
- `_send_deletion_safeguard_notify()` — fail-open HTTP GET to operator-supplied monitoring URLs
- `_set_config()` — reads and sets all new `deletion_safeguard_*` attributes from source config; renamed parameter `harvest_job` → `harvest_item` (accepts both `HarvestJob` and `HarvestObject`)
- `gather_stage()` — calls anomaly detection after fetching records; suppresses `guids_to_delete` when anomaly detected and `allow_bulk_delete` is false; fires monitoring notify for both anomaly and healthy runs
- `_create_organization()` — bug fix: removed `return_id_only` from context to prevent `activity` plugin crashing on a bare string ID

**Config keys** (all optional, source config JSON):

| Key | Default | Notes |
|---|---|---|
| `deletion_safeguard_enabled` | `true` | Set `false` to fully disable |
| `deletion_safeguard_drop_threshold_percent` | `10` | Float 0–100; anomaly when drop exceeds this |
| `deletion_safeguard_min_previous_count` | `100` | Skip check when DB count is below this |
| `deletion_safeguard_allow_bulk_delete` | `false` | `true` to allow deletes to proceed despite anomaly |
| `deletion_safeguard_notify_ok_url` | — | GET on healthy run |
| `deletion_safeguard_notify_anomaly_url` | — | GET on anomaly |
| `deletion_safeguard_heartbeat_url` | — | Legacy: GET `<url>` (ok) / GET `<url>/fail` (anomaly) |

**Test infrastructure** (no tests were passing before this work)
- `pytest>=7.0,<9` in `dev-requirements.txt` (Python 3.12 removed `imp` module used by pytest 4.6.5)
- `pytest.ini` — `addopts = -p no:toolbelt --ckan-ini=test.ini` (disables incompatible ckanext-toolbelt pytest plugin without modifying third-party source; forces minimal test config)
- `test.ini` — minimal plugin set (`datavicmain_dataset hierarchy harvest activity` + harvesters + scheming + alias); uses Docker service names for postgres/solr/redis; requires a separate `ckan_test` database
- `conftest.py` — autouse `_flask_app_context` fixture (pytest ≥ 7 fixture ordering requires explicit request context before factories run)
- 59 tests now passing (was 0)

## Testing notes

### Automated tests

```bash
# Start containers
ahoy up

# One-time: create test database
ahoy ckan
psql postgresql://ckan:ckan@postgres/postgres -c "CREATE DATABASE ckan_test OWNER ckan;"

# Run all tests
ahoy ckan
cd /app/src/ckanext-datavic-harvester && pytest ckanext/datavic_harvester/tests/

# Focus on safeguard tests only
pytest ckanext/datavic_harvester/tests/ -k "safeguard or anomaly or notify"
```

### Manual QA — Scenario A: safeguard blocks mass delete

1. In harvest source config, set:
   ```json
   "test": true,
   "deletion_safeguard_enabled": true,
   "deletion_safeguard_drop_threshold_percent": 10,
   "deletion_safeguard_min_previous_count": 5
   ```
2. Edit `ckanext/datavic_harvester/data/delwp_records.json` — set `records` to ~20 entries. Run harvest. Wait for gather + import to complete (baseline).
3. Shrink `records` to ~3 entries (85% drop). Run harvest again.
4. **Expected:** gather error on the job containing `"anomaly detected"` with `source_count`, `previous_count`, `drop_percent`. No datasets deleted for that run.

### Manual QA — Scenario B: `allow_bulk_delete` override

1. Same setup as Scenario A with a small file in place.
2. Add `"deletion_safeguard_allow_bulk_delete": true` to source config.
3. Run harvest with small file.
4. **Expected:** anomaly may still be logged but delete harvest objects are created and datasets are removed normally.

### Manual QA — Scenario C: monitoring notify

1. Add `"deletion_safeguard_notify_ok_url": "<url>"` and `"deletion_safeguard_notify_anomaly_url": "<url>/fail"` to source config.
2. Run a healthy harvest → verify GET to ok URL.
3. Trigger anomaly (Scenario A) → verify GET to anomaly URL.
4. Verify a network failure on the notify URL does not fail the harvest job.