### PR TITLE
[DATAVIC-949] updated custom harvester source

### DIFF
--- a/ckanext/datavic_harvester/harvesters/dcat_json.py
+++ b/ckanext/datavic_harvester/harvesters/dcat_json.py
@@ -28,6 +28,14 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
             "description": "DataVic Harvester for DCAT dataset descriptions serialized as JSON",
         }
 
+    def validate_config(self, config: Optional[str]) -> str:
+        config_obj = json.loads(super().validate_config(config))
+        self._validate_default_custodian_field(config_obj, "default_data_owner")
+        self._validate_default_custodian_field(
+            config_obj, "default_contact_point"
+        )
+        return json.dumps(config_obj, indent=4)
+
     def gather_stage(self, harvest_job):
         self._set_config(harvest_job.source.config)
         return super().gather_stage(harvest_job)
@@ -235,9 +243,27 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
             pkg_dict["license_id"] = self.config["default_license"]["id"]
             pkg_dict["custom_licence_text"] = self.config["default_license"]["title"]
 
+        if not pkg_dict.get("data_owner") and "default_data_owner" in self.config:
+            pkg_dict["data_owner"] = self.config["default_data_owner"]
+
+        if (
+            not pkg_dict.get("contact_point")
+            and "default_contact_point" in self.config
+        ):
+            pkg_dict["contact_point"] = self.config["default_contact_point"]
+
         pkg_dict["tag_string"] = dcat_dict.get("keyword", [])
 
         pkg_dict.setdefault("update_frequency", "unknown")
+
+    def _validate_default_custodian_field(
+        self, config: dict[str, Any], key: str
+    ) -> None:
+        value = config.get(key)
+        if value is None:
+            return
+        if not isinstance(value, str):
+            raise ValueError(f"{key} must be a string")
 
     def _get_existing_dataset(self, guid: str) -> Optional[dict[str, Any]]:
         """Return a package with specific guid extra if exists"""

--- a/ckanext/datavic_harvester/harvesters/delwp.py
+++ b/ckanext/datavic_harvester/harvesters/delwp.py
@@ -848,6 +848,7 @@ class DelwpHarvester(DataVicBaseHarvester):
 
         self.pkg_dict = pkg_dict = {}
 
+        pkg_dict["contact_point"] = "https://datashare.maps.vic.gov.au/contact-us"
         pkg_dict["personal_information"] = "no"
         pkg_dict["protective_marking"] = "official"
         pkg_dict["access"] = "yes"

--- a/ckanext/datavic_harvester/tests/conftest.py
+++ b/ckanext/datavic_harvester/tests/conftest.py
@@ -163,6 +163,8 @@ def dcat_config(group):
         "default_groups": [group["id"]],
         "default_group_dicts": [group],
         "default_license": {"id": "notspecified", "title": "License not specified"},
+        "default_data_owner": "Default Data Owner",
+        "default_contact_point": "default.contact@example.com",
         "default_full_metadata_url": "https://localhost/metadata/",
         "full_metadata_url_pattern": "localhost/metadata",
     }


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DATAVIC-949

Changes
- updated delwp harvester to support `contact_point`, in this harvester `data_owner` already fallback to harvest source oraganisation or if resowner exist, it will use that.
- updated `dcat_json` so that it can accept new properties, `default_data_owner` and `default_contact_point`. then each harvester can have these 2 values configured in the config UI, see the partial Y mapping in the table of the ticket
