### PR TITLE
[DATAVIC-987] fix harvesting the purged dataset

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,16 @@ jobs:
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test-ci.ini
+    - name: Apply ckanext-dcat patches
+      run: |
+        # Mirrors datavic_ckan_lagoon's Dockerfile.cli patching step. Required
+        # until DATAVIC-987's ckanext-dcat fix (returns delete object ids so
+        # they reach the fetch queue) merges upstream.
+        for patch_file in scripts/patches/ckanext-dcat/*.patch; do
+          [ -f "$patch_file" ] || continue
+          echo "Applying: $(basename "$patch_file")"
+          patch -p1 -d /srv/app/src/ckanext-dcat < "$patch_file"
+        done
     - name: Setup extension
       run: ckan -c test-ci.ini db upgrade
     - name: Run tests

--- a/ckanext/datavic_harvester/data/dcat_json_datasets.txt
+++ b/ckanext/datavic_harvester/data/dcat_json_datasets.txt
@@ -3,1769 +3,145 @@
 	"@type": "dcat:Catalog",
 	"conformsTo": "https://project-open-data.cio.gov/v1.1/schema",
 	"describedBy": "https://project-open-data.cio.gov/v1.1/schema/catalog.json",
-    "dataset": [
-        {
-        "@type": "dcat:Dataset",
-        "identifier": "https://www.arcgis.com/home/item.html?id=74dd92127eea4404b0dad1d7e39bf0e3&sublayer=1",
-        "landingPage": "https://vicroadsopendata-vicroadsmaps.opendata.arcgis.com/maps/vicroadsmaps::road-crashes-for-five-years-victoria",
-        "title": "Road Crashes for five Years Victoria",
-        "description": "<span style='color:rgb(83, 86, 90); font-family:&quot;Avenir Next&quot;, &quot;Avenir Next&quot;; font-size:18px;'>Fatal and injury crashes on Victorian roads during the latest five year reporting period. This data allows users to analyse Victorian fatal and injury crash data based on time, location, conditions, crash type, road user type, object hit etc. Road Safety data is provided by VicRoads for educational and research purposes. This data is in Web Mercator (Auxiliary Sphere) projection.</span><div><span style='color:rgb(83, 86, 90); font-family:&quot;Avenir Next&quot;, &quot;Avenir Next&quot;; font-size:18px;'> </span><a href='https://data.vicroads.vic.gov.au/metadata/Crashes_Last_Five_Years%20-%20Open%20Data.html' rel='nofollow ugc' target='_blank'>About this Data</a></div>",
-        "keyword": [
-            "Crash",
-            "RCIS",
-            "DoT",
-            "EIM"
-        ],
-        "issued": "2021-02-19T11:02:30.000Z",
-        "modified": "2021-10-05T02:14:37.000Z",
-        "publisher": {
-            "name": "Department of Transport"
-        },
-        "contactPoint": {
-            "@type": "vcard:Contact",
-            "fn": "VicRoads",
-            "hasEmail": "mailto:sissupport@roads.vic.gov.au"
-        },
-        "accessLevel": "public",
-        "spatial": "140.7174,-38.9561,149.5451,-34.0182",
-        "license": "http://creativecommons.org/licenses/by/4.0",
-        "distribution": [
-            {
-            "@type": "dcat:Distribution",
-            "title": "ArcGIS Hub Dataset",
-            "format": "Web Page",
-            "mediaType": "text/html",
-            "accessURL": "https://vicroadsopendata-vicroadsmaps.opendata.arcgis.com/maps/vicroadsmaps::road-crashes-for-five-years-victoria"
-            },
-            {
-            "@type": "dcat:Distribution",
-            "title": "ArcGIS GeoService",
-            "format": "ArcGIS GeoServices REST API",
-            "mediaType": "application/json",
-            "accessURL": "https://vicdata.vicroads.vic.gov.au/server/rest/services/SMOP/SMOP_Open_Data_040521/FeatureServer/1"
-            },
-            {
-            "@type": "dcat:Distribution",
-            "title": "GeoJSON",
-            "format": "GeoJSON",
-            "mediaType": "application/vnd.geo+json",
-            "accessURL": "https://vicroadsopendata-vicroadsmaps.opendata.arcgis.com/datasets/vicroadsmaps::road-crashes-for-five-years-victoria.geojson?outSR=%7B%22latestWkid%22%3A3111%2C%22wkid%22%3A102171%7D"
-            },
-            {
-            "@type": "dcat:Distribution",
-            "title": "CSV",
-            "format": "CSV",
-            "mediaType": "text/csv",
-            "accessURL": "https://vicroadsopendata-vicroadsmaps.opendata.arcgis.com/datasets/vicroadsmaps::road-crashes-for-five-years-victoria.csv?outSR=%7B%22latestWkid%22%3A3111%2C%22wkid%22%3A102171%7D"
-            },
-            {
-            "@type": "dcat:Distribution",
-            "title": "KML",
-            "format": "KML",
-            "mediaType": "application/vnd.google-earth.kml+xml",
-            "accessURL": "https://vicroadsopendata-vicroadsmaps.opendata.arcgis.com/datasets/vicroadsmaps::road-crashes-for-five-years-victoria.kml?outSR=%7B%22latestWkid%22%3A3111%2C%22wkid%22%3A102171%7D"
-            },
-            {
-            "@type": "dcat:Distribution",
-            "title": "Shapefile",
-            "format": "ZIP",
-            "mediaType": "application/zip",
-            "accessURL": "https://vicroadsopendata-vicroadsmaps.opendata.arcgis.com/datasets/vicroadsmaps::road-crashes-for-five-years-victoria.zip?outSR=%7B%22latestWkid%22%3A3111%2C%22wkid%22%3A102171%7D"
-            }
-        ],
-        "theme": [
-            "geospatial"
-        ]
-        },
+	"dataset": [
 		{
 			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=dba0069ce11940bab87420344abdff78&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-pumpset-assets",
-			"title": "Water Supply Pumpset Assets",
-			"description": "<div>Layer containing pump sets owned by Melbourne Water and used for water supply. Includes pump station name, description, pump type and other key attributes. This layer is intended to be used to locate and obtain details on Melbourne Water's water supply transfer assets for asset management, buildover (Dial-Before-You-Dig) and operational / maintenance purposes.</div><div><br /></div><div><div>This layer is updated when new information is received from completed projects and updated from certified survey plans. </div></div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
+			"identifier": "https://www.arcgis.com/home/item.html?id=a030f774987d4c95948262025b746989&sublayer=0",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/a030f774987d4c95948262025b746989_0",
+			"title": "Central Highlands Water Water-District",
+			"description": "<p><span style=\"background-color:rgb(255,255,255);color:rgb(74,74,74);font-family:&quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, sans-serif;font-size:16px;\"><span style=\"display:inline !important;float:none;font-style:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-weight:400;letter-spacing:normal;text-align:start;text-decoration-color:initial;text-decoration-style:initial;text-indent:0px;text-transform:none;word-spacing:0px;\">Data containing water service districts in the Central Highland Water service area.</span></span><br><span style=\"background-color:rgb(255,255,255);color:rgb(74,74,74);font-family:&quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, sans-serif;font-size:16px;\"><span style=\"display:inline !important;float:none;font-style:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-weight:400;letter-spacing:normal;text-align:start;text-decoration-color:initial;text-decoration-style:initial;text-indent:0px;text-transform:none;word-spacing:0px;\">Please note: Although Central Highlands Water takes great care in managing its data, we make no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Central Highlands Water shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</span></span></p>",
 			"keyword": [
-				"melbourne water",
-				"water supply",
-				"pumping stations",
-				"pump"
-			],
-			"issued": "2019-10-06T03:03:45.000Z",
-			"modified": "2021-09-15T00:22:35.817Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.7436,-37.9717,146.3590,-37.1734",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-pumpset-assets"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Water_Supply_Pumpset_Assets/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-pumpset-assets.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-pumpset-assets.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-pumpset-assets.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-pumpset-assets.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=4985778f052d4020a6571f777a0f25ab&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::sewerage-network-basins",
-			"title": "Sewerage Network Basins",
-			"description": "<div>This layer delineates sewer catchments upstream of retail water company hydraulic information points. Sewer catchments which contribute directly to Melbourne Water assets are also included. This layer supports Melbourne Water to communicate high level data in regards to the existence and indicative location of assets within its responsibility to ensure they are protected throughout the assets life.</div><div><br /></div><div>This layer is updated when new information is received from completed projects and updated from certified survey plans.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"sewerage",
-				"basin",
-				"boundary",
-				"sewer catchments",
-				"melbourne water"
-			],
-			"issued": "2019-10-06T03:06:01.000Z",
-			"modified": "2019-10-08T02:42:29.043Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.6467,-38.4427,145.7868,-37.6343",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::sewerage-network-basins"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Sewerage_Network_Basins/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::sewerage-network-basins.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::sewerage-network-basins.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::sewerage-network-basins.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::sewerage-network-basins.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=92528ac14cd54a8fa174807839202b65&sublayer=10",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::retarding-basin-assets",
-			"title": "Retarding Basin Assets",
-			"description": "<div>Location and extent of Melbourne Water drainage retarding basins. Captured using the Top Water Level (TWL) of each, includes retarding basin name, asset section (for As Constructed drawings) and other key attributes. This layer is intended to be used to locate and obtain details on Melbourne Water's drainage assets for asset management and operational / maintenance purposes.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"melbourne water",
-				"retarding basins",
-				"drainage",
-				"RB",
-				"waterways"
-			],
-			"issued": "2019-10-07T04:43:16.000Z",
-			"modified": "2019-10-11T05:32:31.596Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.4071,-38.4811,145.8852,-37.3855",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::retarding-basin-assets"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Retarding_Basin_Assets/FeatureServer/10"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::retarding-basin-assets.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::retarding-basin-assets.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::retarding-basin-assets.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::retarding-basin-assets.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=f20c34e8cafd49eb848e0f90c9822c0e&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::recycled-water-main-pipelines",
-			"title": "Recycled Water Main Pipelines",
-			"description": "<div>Layer containing reclaimed water (recycled) mains and associated details. Includes description, asset section (for As Constructed drawings) and key attributes. Recycled water is supplied to Melbourne's retail water companies – <a href='https://www.citywestwater.com.au/saving_water/recycled_water.aspx'>City West Water</a>, <a href='https://southeastwater.com.au/LearnAboutWater/TypesWater/Pages/RecycledWater.aspx'>South East Water</a> and <a href='https://www.yvw.com.au/help-advice/recycled-water'>Yarra Valley Water</a>. This layer supports Melbourne Water to communicate high level data in regards to the existence and indicative location of assets within its responsibility, to ensure they are protected throughout the assets life. </div><div><br /></div><div>This layer is updated when new information is received from completed projects and updated from certified survey plans. </div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"recycled water",
-				"melbourne water assets",
-				"water supply",
-				"melbourne",
-				"mains",
-				"transfer network",
-				"assets"
-			],
-			"issued": "2019-11-13T05:45:26.000Z",
-			"modified": "2020-09-03T23:18:00.735Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.6284,-38.1712,145.3811,-37.9216",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::recycled-water-main-pipelines"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Recycled_Water_Main/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::recycled-water-main-pipelines.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::recycled-water-main-pipelines.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::recycled-water-main-pipelines.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::recycled-water-main-pipelines.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=ca7bc6087ede4181861f8379fe55eb24&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-vegetation-extent-priority-for-streams",
-			"title": "HWS2018 Vegetation Extent Priority for Streams",
-			"description": "<div>Data describes vegetation extent priorities for each stream reach across the Melbourne Water region. Each reach is classified as either high, medium or low priority. To meet the performance objectives of the Healthy Waterways Strategy 2018 (HWS2018), high priority reaches need to be revegetated by 2028. To meet the target trajectory scores of the Healthy Waterways Strategy, medium priority reaches need to be revegetated by 2068. Vegetation priority reaches were determined by a combination of decision support tools and the co-design process. The decision support tool used was Zonation, which prioritised management actions across the region with the objective of improving instream habitat suitability for platypus, fish and macroinvertebrates.</div><div><br /></div><div>For the most up-to-date performance objectives, see the co-designed Catchment Programs at: <a href='https://www.melbournewater.com.au/about-us/strategies-achievements-and-policies/healthy-waterways-strategy' rel='nofollow ugc'>https://www.melbournewater.com.au/about-us/strategies-achievements-and-policies/healthy-waterways-strategy</a> </div><div><br /></div><div>Results are considered fit for purpose (i.e. for waterway planning). This data set covers the entire Melbourne Water region with the exception of very small areas close to Port Phillip Bay or Western Port. For example, there are small areas of French Island which are not captured.</div><div><br /></div><div>This data set was created using: 1. Streams dataset for the Healthy Waterways Strategy 2018. This layer was developed by GraceGIS using Melbourne Water layers as inputs.</div><div><br /></div><div>For further reading on the prioritisation process see:</div><div>• Chee et al. (in development), Habitat Suitability Models, Scenarios and Quantitative Action Prioritisation (using Zonation) for Melbourne Water’s Healthy Waterways Strategy: A Resource Document, University of Melbourne and Melbourne Water for Melbourne Waterways Research Practice Partnership</div><div>• Melbourne Water (in development), Healthy Waterways Strategy Resource Document, Presentation of revegetation priority reaches for the Healthy Waterways Strategy 2018.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Healthy Waterways Strategy 2018",
-				"Vegetation",
-				"Revegetation",
-				"Canopy",
-				"Waterways",
-				"Streams",
-				"Land"
-			],
-			"issued": "2019-09-05T07:35:49.000Z",
-			"modified": "2020-02-05T06:53:47.003Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0836,-38.4941,146.1648,-37.2301",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-vegetation-extent-priority-for-streams"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/VEG_EXTENT_PRIORITY_HWS/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-vegetation-extent-priority-for-streams.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-vegetation-extent-priority-for-streams.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-vegetation-extent-priority-for-streams.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-vegetation-extent-priority-for-streams.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=2c538ef097b64702afa908d484cbffda&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-subcatchments-with-2016-vegetation-metrics-for-riparian-and-stream-bed",
-			"title": "HWS2018 Subcatchments with 2016 vegetation metrics for Riparian and Stream Bed",
-			"description": "<div>Data represents vegetation coverage within the riparian zone for waterways across Melbourne Water’s region. This layer was developed by GraceGIS as part of vegetation statistics extraction for each riparian zone and stream bed for each of the subcatchments. The data was developed as part of the Healthy Waterways Strategy 2018 (HWS2018). The primary purpose of this layer is for reporting and target setting. This includes setting and reporting on targets and performance objectives relating to vegetation coverage.</div><div><br /></div><div>Dataset was created using 1. Latest MW Drainage Network to prepare HWS stream network layer. 2. Seamless polygons were created for the stream bed: ISC 2010 streambed data and a 2 metre buffer from the network was used to develop a complete streambed layer across the Melbourne Water region. 3. Buffer polygons at 20 metres and 10 metres from the streambed representing riparian zone outside Urban Growth Boundary (UGB) area and within UGB respectively. 4. HWS Vegetation Streambed Riparian (2016) layer for these riparian and stream beds has been assembled. 5. Subc level stats are derived as detailed above.</div><div><br /></div><div>Attribute level metadata can be viewed <a href='https://melbournewater.maps.arcgis.com/home/item.html?id=2c538ef097b64702afa908d484cbffda&amp;view=list#data' rel='nofollow ugc' target='_blank'>here</a></div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Healthy Waterways Strategy 2018",
-				"Vegetation",
-				"Subcatchment",
-				"Land",
-				"Riparian Zone",
-				"Waterways"
-			],
-			"issued": "2019-09-05T14:00:57.000Z",
-			"modified": "2019-09-13T22:41:53.654Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0723,-38.5425,146.1698,-37.2264",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-subcatchments-with-2016-vegetation-metrics-for-riparian-and-stream-bed"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/HWS_Subc_Veg_Metrics/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-subcatchments-with-2016-vegetation-metrics-for-riparian-and-stream-bed.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-subcatchments-with-2016-vegetation-metrics-for-riparian-and-stream-bed.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-subcatchments-with-2016-vegetation-metrics-for-riparian-and-stream-bed.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-subcatchments-with-2016-vegetation-metrics-for-riparian-and-stream-bed.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=3136c8165eff4bbdba8edf184776643d&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::melbourne-wastewater-treatment-east-daily-grid-electricity-consumption",
-			"title": "Melbourne Wastewater Treatment (East) - Daily Grid Electricity Consumption",
-			"description": "<div>Daily accumulated electricity supply (kWh) and daily accumulated electricity generation (kWh) into the Eastern Treatment Plant (ETP) of Melbourne Water. This data is collected using revenue quality meters across each supply line (feeder) into the plant, and Melbourne Water owned power meters for generation measurements. Melbourne Water collects and stores this feeder data as 15 minute interval data, and the generation data at real time. The data in this file summarises the electricity consumption and generation as daily usage. The time period associated with each day has been converted to a UTC time zone. This data set allows year on year comparison or daily usage against atmospheric changes i.e. temperature variance, rainfall. Feeder 1 and Feeder 2 can be combined to obtain the total Grid Electricity Consumption for ETP, and combined with the total electricity Generation to obtain the total Electricity consumption for ETP.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Open Data"
-			],
-			"issued": "2019-09-02T03:14:02.000Z",
-			"modified": "2021-04-09T06:12:22.213Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "145.1485,-38.0723,145.1854,-38.0462",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::melbourne-wastewater-treatment-east-daily-grid-electricity-consumption"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_ETP_Daily_ElectricityUse_From2014/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::melbourne-wastewater-treatment-east-daily-grid-electricity-consumption.geojson"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::melbourne-wastewater-treatment-east-daily-grid-electricity-consumption.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=7c0e5ccf71854e60bb77345dc26ddb76&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-main-pipelines",
-			"title": "Water Supply Main Pipelines",
-			"description": "<div>Layer containing water main centre lines and associated details. Includes water main name, description, asset section (for As Constructed drawings) and key attributes for water transfer pipes, bypass connections, aqueducts. This layer is intended to be used to locate and obtain details on Melbourne Water's water supply transfer assets for asset management, buildover (Dial-Before-You-Dig) and operational / maintenance purposes.</div><div><br /></div><div>This layer is updated when new information is received from completed projects and updated from certified survey plans.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div><div><br /></div>",
-			"keyword": [
-				"melbourne water",
-				"water supply",
-				"mains",
-				"water supply mains",
-				"transfer network",
-				"wholesale infrastructure",
-				"assets"
-			],
-			"issued": "2019-11-18T01:31:42.000Z",
-			"modified": "2020-10-28T02:07:42.604Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.4917,-38.3355,146.4063,-37.1728",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-main-pipelines"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Water_Supply_Main_Pipelines/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-main-pipelines.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-main-pipelines.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-main-pipelines.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-main-pipelines.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=f927c73700a9481aaac35f8f40923b86&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::sewerage-network-main-pipelines",
-			"title": "Sewerage Network Main Pipelines",
-			"description": "<div>Layer containing sewer main centrelines and associated details. Includes sewer name, description, asset section (for As Constructed drawings) and key attributes for gravity mains, pressure (rising) mains, effluent reuse / recycling pipes. This layer supports Melbourne Water to communicate high level data in regards to the existence and indicative location of assets within its responsibility to ensure they are protected throughout the assets life.</div><div><br /></div><div>This layer is updated when new information is received from completed projects and updated from certified survey plans.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"melbourne water",
-				"sewer main",
-				"sewerage",
-				"mains",
-				"wastewater",
-				"transfer network",
-				"assets"
-			],
-			"issued": "2019-11-18T01:09:08.000Z",
-			"modified": "2021-12-15T21:18:07.522Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.6311,-38.4361,145.2738,-37.7148",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::sewerage-network-main-pipelines"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Sewerage_Network_Mains/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::sewerage-network-main-pipelines.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::sewerage-network-main-pipelines.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::sewerage-network-main-pipelines.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::sewerage-network-main-pipelines.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=1d833903f2464109bf1f2b5b3d84dacd&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::melbourne-drain-and-waterway-outlets",
-			"title": "Melbourne drain and waterway outlets",
-			"description": "<p><span style='font-size:9.0pt;font-family:&quot;Verdana&quot;,sans-serif;\ncolor:black'>This data contains points representing drain and waterway outlet\nlocations, associated with a natural waterway or channel centreline, within the\nGreater Melbourne region. This region includes the Port Phillip Bay and Western\nPort coastlines. Points are captured to show the indicative location of the\nendpoint for a waterway or channel as geographic coordinates.</span></p>\n\n<p><span style='font-size:9.0pt;font-family:&quot;Verdana&quot;,sans-serif;\ncolor:black'>The data table includes minimal attributes to assist in\nidentifying the feature.</span></p>\n\n<p><span style='font-size:9.0pt;font-family:&quot;Verdana&quot;,sans-serif;\ncolor:black'>Data was created using the waterway (Reach) layer from original FIS\n1:50K (Vicmap Hydro) streams data set, which included only those waterways\nwithin catchments of greater than 60ha. Waterways (Reach) Rectification project\nundertaken 2001 to 2003 to review and correct the extent of the waterways reach\nnetwork to ensure a complete data set exists (using the Drainage Metropolis\nBoundary, 50K data, 1:2500 Drainage Record Plans, Drainage Limits data,\northophotos, as constructed and/or design drawings, contour data and Melway\nStreet Directory). Waterway (Reach) extents defined and attributes populated in\nGIS and AMIS for all records including assigning nodes and node numbers (for\nstart / end points) and removing any reaches less than 100 metres in length\nthat are predominantly channel assets. Waterways in extended area incorporated\nin 2005 using Vicmap Hydro data and aerial imagery, then updated in 2009/10\nusing Lidar survey data (contours). Data is maintained using Lidar survey data\n(contours) and 60 ha limits. Please refer to metadata for each dataset row\nrecord for specific source / accuracy information.</span></p>\n\n<p><span style='font-size:9.0pt;font-family:&quot;Verdana&quot;,sans-serif;\ncolor:black'> </span></p>\n\n<span style='font-size:9.0pt;font-family:&quot;Verdana&quot;,sans-serif;mso-fareast-font-family:\nCalibri;mso-fareast-theme-font:minor-latin;mso-bidi-font-family:Calibri;\ncolor:black;mso-ansi-language:EN-AU;mso-fareast-language:EN-US;mso-bidi-language:\nAR-SA'><i>NOTE: Whilst every effort has been taken in collecting, validating and\nproviding the attached data, Melbourne Water Corporation makes no\nrepresentations or guarantees as to the accuracy or completeness of this data.\nAny person or group that uses this data does so at its own risk and should make\ntheir own assessment and investigations as to the suitability and/or\napplication of the data. Melbourne Water Corporation shall not be liable in any\nway to any person or group for loss of any kind including damages, costs,\ninterest, loss of profits or special loss or damage, arising from any use,\nerror, inaccuracy, incompleteness or other defect in this data.</i></span>",
-			"keyword": [
-				"Transfer Network",
-				"Wholesale",
-				"Infrastructure",
-				"Assets",
-				"Water",
-				"Hydrology",
-				"Land",
-				"Topography",
-				"Agriculture",
-				"Irrigation",
-				"Melbourne",
-				"Waterways"
-			],
-			"issued": "2020-08-14T02:13:01.000Z",
-			"modified": "2020-08-14T02:26:10.424Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0834,-38.4993,146.1648,-37.2301",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::melbourne-drain-and-waterway-outlets"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Melbourne_drain_and_waterway_outlets/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::melbourne-drain-and-waterway-outlets.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::melbourne-drain-and-waterway-outlets.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::melbourne-drain-and-waterway-outlets.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::melbourne-drain-and-waterway-outlets.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=15c3c23d7ef140b4a746e7779eae92d7&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::catchments-waterways-and-drains-subcatchments",
-			"title": "Catchments - Waterways and Drains Subcatchments",
-			"description": "<div>Catchment area for each Melbourne Water drain. Captured using available contours and drainage network information. This layer has two intended purposes: </div><div><ol><li>To enable the identification of the receiving Melbourne Water waterway/drain for any property, area or point. </li><li>To provide a framework of catchments for hydrologic modelling that can be further divided or amalgamated to suit the needs of the modeller.</li></ol></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.<br /></div>",
-			"keyword": [
-				"drainage",
-				"waterways",
-				"catchments",
-				"melbourne",
-				"boundaries",
-				"land",
-				"hydraulic modelling",
-				"hydrology",
-				"stormwater"
-			],
-			"issued": "2019-10-06T03:21:33.000Z",
-			"modified": "2019-12-04T01:51:16.415Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0723,-38.5425,146.1698,-37.2264",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::catchments-waterways-and-drains-subcatchments"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Catchments_of_all_Waterways_and_Drains/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-waterways-and-drains-subcatchments.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-waterways-and-drains-subcatchments.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-waterways-and-drains-subcatchments.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-waterways-and-drains-subcatchments.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=137150aa1de74bfb9afcfb152c231560&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::recycled-water-annual-volumes-supplied-by-melbourne-water",
-			"title": "Recycled Water Annual Volumes Supplied by Melbourne Water",
-			"description": "<div>Melbourne Water treats effluent to Class A recycled water standard. A proportion of this water is used onsite and provided to retail water companies to sell to recycled water customers.  This file contains annual volumes of recycled water use and sales as reporting in the organisation's annual report.</div><div><br /></div><div>NOTE. Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"water supply",
-				"wastewater",
-				"water usage",
-				"recycled water",
-				"melbourne",
-				"eastern treatment plant"
-			],
-			"issued": "2019-09-05T13:26:21.000Z",
-			"modified": "2019-09-20T06:21:11.289Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "143.5310,-38.8620,146.6510,-36.9560",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::recycled-water-annual-volumes-supplied-by-melbourne-water"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_Annual_RecycledWaterUseVolumes_From2012/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::recycled-water-annual-volumes-supplied-by-melbourne-water.geojson"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::recycled-water-annual-volumes-supplied-by-melbourne-water.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=ab54f1679c3d4dd6b0f4030634fce861&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-daily-volume-drawn-from-storage-dams-operated-by-melbourne-water",
-			"title": "Water Supply - Daily Volume Drawn from storage dams operated by Melbourne Water",
-			"description": "This data provides daily accumulated water usage volumes supplied from the 10 Melbourne Water storages. This data is collected using more than 120 Flow Monitoring devices across Melbourne Water's Water Transfer Pipe Network, linked to the Telemetry System. Melbourne Water collects and stores observations at six minute intervals. This data summarises the usage volume supplied by Melbourne Water over a 24 hour period (8am to 8am). Water recipients include 3 metro water retailer companies and 5 regional water authorities. This data set is best used in long and short term water demand analysis.<div><br /></div><div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div></div>",
-			"keyword": [
-				"Open Data",
-				"water supply",
-				"water usage",
-				"consumption",
-				"water demand",
-				"daily demands",
-				"flowmeter"
-			],
-			"issued": "2019-09-02T02:41:50.000Z",
-			"modified": "2020-03-19T02:10:57.405Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.5206,-38.5699,146.4858,-37.3439",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-daily-volume-drawn-from-storage-dams-operated-by-melbourne-water"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_Daily_BulkWaterSupply_CompleteRecord/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-daily-volume-drawn-from-storage-dams-operated-by-melbourne-water.geojson"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-daily-volume-drawn-from-storage-dams-operated-by-melbourne-water.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=7db00ccb52134f53991257edfe37cade&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-daily-volume-observed-for-storage-dams-operated-by-melbourne-water",
-			"title": "Water Supply - Daily Volume observed for storage dams operated by Melbourne Water",
-			"description": "<div>Daily observed Storage Dam Volumes at 10 Water Storage Dams operated by Melbourne Water. This data is collected with telemetry devices installed at the storage dams, and verified with field observations.  The storage volume is recorded at 8:00 am daily. This data is best used in long term storage volume analysis.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Open Data",
-				"water supply",
-				"storage dams",
-				"dam levels",
-				"volumes",
+				"CHW_Open_Water_Data",
+				"network",
 				"water"
 			],
-			"issued": "2019-09-02T03:16:14.000Z",
-			"modified": "2020-03-19T02:10:44.837Z",
+			"issued": "2026-06-16T23:46:07.000Z",
+			"modified": "2026-06-16T23:46:20.220Z",
 			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
+				"name": "{{source}}"
 			},
 			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
+				"@type": "vcard:Contact",
+				"fn": "nic.hendriks@chw.net.au_chw",
+				"hasEmail": "{{orgContactEmail}}"
 			},
 			"accessLevel": "public",
-			"spatial": "143.5310,-38.8620,146.6510,-36.9560",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
+			"spatial": "-180.0000,-85.0511,180.0000,85.0511",
+			"license": "<p><span style=\"background-color:rgb(255,255,255);color:rgb(74,74,74);font-family:&quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, sans-serif;font-size:16px;\"><span style=\"display:inline !important;float:none;font-style:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-weight:400;letter-spacing:normal;text-align:start;text-decoration-color:initial;text-decoration-style:initial;text-indent:0px;text-transform:none;word-spacing:0px;\">Creative Commons Attribution Share-Alike 4.0 International</span></span></p>",
 			"distribution": [
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS Hub Dataset",
 					"format": "Web Page",
 					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-daily-volume-observed-for-storage-dams-operated-by-melbourne-water"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/a030f774987d4c95948262025b746989_0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS GeoService",
 					"format": "ArcGIS GeoServices REST API",
 					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_Daily_StorageVolume_CompleteRecord/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-daily-volume-observed-for-storage-dams-operated-by-melbourne-water.geojson"
+					"accessURL": "https://services9.arcgis.com/JGBDKYQnfMPTEusx/arcgis/rest/services/Central_Highlands_Water_Water_District/FeatureServer/0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "CSV",
 					"format": "CSV",
 					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-daily-volume-observed-for-storage-dams-operated-by-melbourne-water.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=c6eab1b4aa3e40939f35b6ee4952ddb0&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-daily-streamflow-into-melbournes-4-major-harvesting-storage-dams",
-			"title": "Water Supply - Daily Streamflow (into Melbourne's 4 Major Harvesting Storage Dams)",
-			"description": "<div>This dataset provides daily measured streamflows into the four (4) major harvesting catchment dams in megalitres (ML). The streamflow is a calculated value which represents the observed 24-hour accumulated streamflow into the dam; net of any evaporation losses or rainfall gains from the dam surface. The streamflow measurement process requires reservior level, reservior gains and dam outflow data. The reservior level and dam outflow data is collected using telemetry devices. The reserviour levels are validated by Melbourne Water field operators. The dam outflow accounts for all water releases, including for consumption and for environmental purposes . The data is recorded at 8am daily. This data can be used in long and short-term catchment streamflow analysis.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Open Data",
-				"water supply",
-				"catchment streamflows",
-				"storage dams",
-				"dam levels",
-				"volumes",
-				"water"
-			],
-			"issued": "2019-09-02T03:17:46.000Z",
-			"modified": "2020-03-19T02:09:42.289Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.4758,-38.5820,146.6510,-37.2772",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-daily-streamflow-into-melbournes-4-major-harvesting-storage-dams"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_Daily_MajorStorageStreamflow_CompleteRecord/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-daily-streamflow-into-melbournes-4-major-harvesting-storage-dams.geojson"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-daily-streamflow-into-melbournes-4-major-harvesting-storage-dams.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=1e7818ddbdea415c83e0fe1f8b6e7fc2&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::melbourne-wastewater-daily-volume-received-by-melbourne-water",
-			"title": "Melbourne Wastewater - Daily Volume Received by Melbourne Water",
-			"description": "<div>This data provides daily accumulated inflow volumes for wastewater treatment at the two Melbourne Water site (Western and Eastern). This data is collected using network flow monitoring devices. This data has been processed and stored as official inflow volumes received by Melbourne Water over a 24 hour period (12am to 12am). Wastewater volume is the total accumulated flow received from the sewer and stormwater networks. This data set is best used in long and short term wastewater services demand analysis. </div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"wastewater",
-				"transfer network",
-				"wholesale",
-				"stormwater",
-				"sewage",
-				"sewerage",
-				"volume",
-				"flowrate",
-				"melbourne",
-				"eastern treatment plant",
-				"western treatment plant",
-				"daily"
-			],
-			"issued": "2019-09-05T13:31:23.000Z",
-			"modified": "2020-03-19T02:08:25.726Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "143.5310,-38.8620,146.6510,-36.9560",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::melbourne-wastewater-daily-volume-received-by-melbourne-water"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_Daily_BulkWastewaterInflow_From1995/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::melbourne-wastewater-daily-volume-received-by-melbourne-water.geojson"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::melbourne-wastewater-daily-volume-received-by-melbourne-water.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=c9bd7401a6274d178ed745b92d1c0ab0&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-daily-rainfall-at-the-4-major-harvesting-storage-dams",
-			"title": "Water Supply - Daily Rainfall (at the 4 Major Harvesting Storage Dams)",
-			"description": "<div>Daily point rainfall values. This data is collected with rainfall telemetry devices installed at the catchment storage dams, and verified with field observations daily.  This data provides daily rainfall observed for the 24hr period from 8am to 8am. This data provides our customers and community with the daily observed rainfall information. This data is best used in long term rainfall analysis at the four major melbourne storage dams (Maroondah; O'Shannassy; Thomson; and Upper Yarra). This dataset is not suitable for event modelling which requires higher frequency observations.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Open Data",
-				"water supply",
-				"rain",
-				"rainfall",
-				"telemetry",
-				"storage dams",
-				"catchments"
-			],
-			"issued": "2019-09-02T03:18:38.000Z",
-			"modified": "2020-03-19T02:07:32.560Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.7055,-38.0743,146.4290,-37.4064",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-daily-rainfall-at-the-4-major-harvesting-storage-dams"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_Daily_MajorCatchmentRainfall_CompleteRecord/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-daily-rainfall-at-the-4-major-harvesting-storage-dams.geojson"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-daily-rainfall-at-the-4-major-harvesting-storage-dams.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=4af9de57e1c14541870905c209498a5c&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-habitat-suitability-modelling-results-for-platypus",
-			"title": "HWS2018 Habitat suitability modelling results for Platypus",
-			"description": "<div>Data describes habitat suitability modelling (HSM) results for platypus. The data was developed by the University of Melbourne through the Melbourne Waterways Research Practice Partnership as part of the development of Melbourne Water’s Healthy Waterways Strategy 2018 (HWS2018). Analysis has been undertaken across the Melbourne Water operating region, where the operating region has been divided into 16,346 sub-catchments. Of these 16,346 subcatchments, 8233 contain Melbourne Water waterways. The results are presented for each of these 8233 reaches. The data was used to estimate scores for platypus presented in the HWS for three scenarios:</div><div><ul><li>Current: habitat suitability for platypus under current conditions (i.e. 2014).</li><li>Current trajectory: habitat suitability for platypus under urbanisation and climate change scenarios if current management approaches continue.</li><li>Target trajectory: habitat suitability for platypus given urbanisation and climate change (as for current trajectory), together with (a) delivery of performance objectives of the Healthy Waterways Strategy and (b) achievement of environmental condition scores as described in the Catchment Programs of the Healthy Waterways Strategy. Presentation of habitat suitabilty model results for platypus from the Healthy Waterways Strategy 2018. </li></ul></div><div><br /></div><div>Habitat Suitability Model results have been thoroughly reviewed and are considered fit for purpose (i.e. for waterway planning). This data set covers the entire Melbourne Water region with the exception of very small areas close to Port Phillip Bay or Western Port. For example, there are small areas of French Island which are not captured.</div><div><br /></div><div>This data set was created using: 1. Streams dataset for the Healthy Waterways Strategy 2018. This layer was developed by GraceGIS using Melbourne Water layers as inputs. 2. Results from Habitat Suitability Modelling for the Healthy Waterways Strategy 2018. </div><div><br /></div><div>Further reading: Chee et al. (in development), Habitat Suitability Models, Scenarios and Quantitative Action Prioritisation (using Zonation) for Melbourne Water’s Healthy Waterways Strategy: A Resource Document, University of Melbourne and Melbourne Water for Melbourne Waterways Research Practice Partnership Melbourne Water (in development), Healthy Waterways Strategy Resource Document</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Healthy Waterways Strategy 2018",
-				"Stormwater",
-				"Harvest",
-				"Infiltrate",
-				"Waterways",
-				"Hydrology",
-				"Impervious",
-				"Disconnection",
-				"Land"
-			],
-			"issued": "2019-09-05T13:31:03.000Z",
-			"modified": "2020-08-31T05:42:06.952Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0836,-38.4941,146.1648,-37.2301",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-habitat-suitability-modelling-results-for-platypus"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/PLATY_HSM_HWS/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-platypus.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-platypus.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-platypus.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/a030f774987d4c95948262025b746989/csv?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "Shapefile",
 					"format": "ZIP",
 					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-platypus.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=4310d5bcf21a42bbb2103a51892fc9f8&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-storage-dams-major-system-storage",
-			"title": "Water Supply Storage Dams (Major System Storage)",
-			"description": "<div>Layer containing water supply storage dams (location and extent). These are major water supply system storages. Captured using as-constructed drawings and aerial imagery, and includes storage dam name, category / type, asset identifier, as=-constructed plan references plus other key attributes. This layer is intended to be used to locate and obtain details on Melbourne Water's water supply transfer assets for asset management, buildover (Dial-Before-You-Dig) and operational or maintenance purposes.</div><div><br /></div><div>This layer is updated when new information is received from completed projects and/or updated from certified survey plans. Melbourne Water are responsible for reviewing and accepting information which results in update to the existing layer.</div><div><br /></div><div>Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"water supply assets",
-				"water supply",
-				"transfer network",
-				"wholesale",
-				"infrastructure assets",
-				"dams"
-			],
-			"issued": "2019-09-03T03:19:11.000Z",
-			"modified": "2020-08-14T02:37:42.733Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.8816,-38.0069,146.4062,-37.4837",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-storage-dams-major-system-storage"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/WS_Storage_Dam_OpenData/FeatureServer/0"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/a030f774987d4c95948262025b746989/shapefile?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "GeoJSON",
 					"format": "GeoJSON",
 					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-storage-dams-major-system-storage.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-storage-dams-major-system-storage.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/a030f774987d4c95948262025b746989/geojson?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "KML",
 					"format": "KML",
 					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-storage-dams-major-system-storage.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/a030f774987d4c95948262025b746989/kml?layers=0"
+				}
+			],
+			"theme": [
+				"geospatial"
+			]
+		},
+		{
+			"@type": "dcat:Dataset",
+			"identifier": "https://www.arcgis.com/home/item.html?id=5cd164e3234e4a6da38cb19afe5bcf58&sublayer=0",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/5cd164e3234e4a6da38cb19afe5bcf58_0",
+			"title": "Central Highlands Water Sewer-District",
+			"description": "<p><span style='background-color:rgb(255,255,255); color:rgb(74,74,74); font-family:&quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, sans-serif; font-size:16px;'><span style='display:inline !important; float:none; font-style:normal; font-variant-caps:normal; font-variant-ligatures:normal; font-weight:400; letter-spacing:normal; text-align:start; text-decoration-color:initial; text-decoration-style:initial; text-indent:0px; text-transform:none; word-spacing:0px;'>Data containing sewer service districts in the Central Highland Water service area.</span></span><br /><span style='background-color:rgb(255,255,255); color:rgb(74,74,74); font-family:&quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, sans-serif; font-size:16px;'><span style='display:inline !important; float:none; font-style:normal; font-variant-caps:normal; font-variant-ligatures:normal; font-weight:400; letter-spacing:normal; text-align:start; text-decoration-color:initial; text-decoration-style:initial; text-indent:0px; text-transform:none; word-spacing:0px;'>Please note: Although Central Highlands Water takes great care in managing its data, we make no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Central Highlands Water shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</span></span></p>",
+			"keyword": [
+				"CHW_Open_Sewer_Data",
+				"network",
+				"sewer"
+			],
+			"issued": "2026-06-16T23:24:34.000Z",
+			"modified": "2026-06-16T23:24:44.927Z",
+			"publisher": {
+				"name": "{{source}}"
+			},
+			"contactPoint": {
+				"@type": "vcard:Contact",
+				"fn": "nic.hendriks@chw.net.au_chw",
+				"hasEmail": "{{orgContactEmail}}"
+			},
+			"accessLevel": "public",
+			"spatial": "-180.0000,-85.0511,180.0000,85.0511",
+			"license": "<p><span style='background-color:rgb(255,255,255); color:rgb(74,74,74); font-family:&quot;Avenir Next&quot;, Avenir, &quot;Helvetica Neue&quot;, sans-serif; font-size:16px;'><span style='display:inline !important; float:none; font-style:normal; font-variant-caps:normal; font-variant-ligatures:normal; font-weight:400; letter-spacing:normal; text-align:start; text-decoration-color:initial; text-decoration-style:initial; text-indent:0px; text-transform:none; word-spacing:0px;'>Creative Commons Attribution Share-Alike 4.0 International</span></span></p>",
+			"distribution": [
+				{
+					"@type": "dcat:Distribution",
+					"title": "ArcGIS Hub Dataset",
+					"format": "Web Page",
+					"mediaType": "text/html",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/5cd164e3234e4a6da38cb19afe5bcf58_0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "ArcGIS GeoService",
+					"format": "ArcGIS GeoServices REST API",
+					"mediaType": "application/json",
+					"accessURL": "https://services9.arcgis.com/JGBDKYQnfMPTEusx/arcgis/rest/services/Central_Highlands_Water_Sewer_District/FeatureServer/0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "CSV",
+					"format": "CSV",
+					"mediaType": "text/csv",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/5cd164e3234e4a6da38cb19afe5bcf58/csv?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "Shapefile",
 					"format": "ZIP",
 					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-storage-dams-major-system-storage.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=ccbcb0ba949b43dca75311aa1137e3fc&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::wastewater-outlet-daily-treated-water-quality-eastern-treatment-plant-etp-",
-			"title": "Wastewater Outlet - Daily Treated Water Quality - Eastern Treatment Plant (ETP) ",
-			"description": "<div>The Eastern Treatment Plant (ETP) discharges treated effluent  in accordance with EPA Victoria licence AL74284 to an ocean outfall at Boag Rocks. This file contains selected discharge quality data. Samples are taken as a grab sample at the time stamp shown in the file. Results are in milligrams per litre.</div><div><br /></div><div>Quality parameters include: Ammonia (Ammonia as N) (mg/L), Biochemical Oxygen Demand (BOD) (mg/L), Chemical Oxygen Demand (COD) (mg/L), Nitrate plus Nitrite (mg/L), Nitrogen (Nitrogen (total)) (mg/L).</div><div><br /></div><div>NOTE. Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"wastewater",
-				"treatment",
-				"water quality",
-				"recycled water",
-				"melbourne",
-				"eastern treatment plant"
-			],
-			"issued": "2019-09-05T13:16:26.000Z",
-			"modified": "2019-09-05T14:30:36.565Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "143.5310,-38.8620,146.6510,-36.9560",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::wastewater-outlet-daily-treated-water-quality-eastern-treatment-plant-etp-"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_ETP_Daily_EffluentQuality_From2014/FeatureServer/0"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/5cd164e3234e4a6da38cb19afe5bcf58/shapefile?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "GeoJSON",
 					"format": "GeoJSON",
 					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wastewater-outlet-daily-treated-water-quality-eastern-treatment-plant-etp-.geojson"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wastewater-outlet-daily-treated-water-quality-eastern-treatment-plant-etp-.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=b2f0498806784746b72e98c49632d1b3&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::wastewater-inlet-hourly-flow-eastern-treatment-plant-etp-",
-			"title": "Wastewater Inlet - Hourly Flow - Eastern Treatment Plant (ETP) ",
-			"description": "<div>The Eastern Treatment Plant (ETP) receives sewage from the eastern side of Melbourne. This file describes the volume of sewage pumped through ETP on an hourly basis.</div><div><br /></div><div>NOTE. Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"wastewater",
-				"transfer network",
-				"wholesale",
-				"stormwater",
-				"sewage",
-				"sewerage",
-				"volume",
-				"flowrate",
-				"melbourne",
-				"eastern treatment plant"
-			],
-			"issued": "2019-09-05T13:22:33.000Z",
-			"modified": "2019-09-05T14:30:18.398Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "143.5310,-38.8620,146.6510,-36.9560",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::wastewater-inlet-hourly-flow-eastern-treatment-plant-etp-"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_ETP_Hourly_InfluentFlow_From2009/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wastewater-inlet-hourly-flow-eastern-treatment-plant-etp-.geojson"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wastewater-inlet-hourly-flow-eastern-treatment-plant-etp-.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=2bd028b25c3041c9873f9bff12d39413&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::wastewater-inlet-daily-raw-water-quality-eastern-treatment-plant-etp",
-			"title": "Wastewater Inlet - Daily Raw Water Quality - Eastern Treatment Plant (ETP)",
-			"description": "<div>The Eastern Treatment Plant (ETP) receives sewage from the eastern side of Melbourne. This file describes the quality of the sewage received by providing results of regular sampling.</div><div>The sample is taken with a flow-weighted auto-sampler. Samples are collected at 7:00 AM each day and relate to the previous 24 hours (e.g. timestamp of 5/1/19 07:00 was sampled between 4/1/19 07:00 and 5/1/19 07:00). Results are in milligrams per litre (mg/L). To calculate an incoming load in raw sewage, match this with wastewater inlet hourly flow for the same time period (as noted in the example).</div><div><br /></div><div>Quality parameters include: Ammonia (Ammonia as N) (mg/L), Biochemical Oxygen Demand (BOD) (mg/L), Chemical Oxygen Demand (COD) (mg/L), Nitrate plus Nitrite (mg/L), Nitrogen (Nitrogen (total)) (mg/L).</div><div><br /></div><div>NOTE. Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"wastewater",
-				"stormwater",
-				"treatment",
-				"sewage",
-				"sewerage",
-				"water quality",
-				"melbourne",
-				"eastern treatment plant"
-			],
-			"issued": "2019-09-05T13:04:36.000Z",
-			"modified": "2019-09-05T14:29:51.316Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "143.5310,-38.8620,146.6510,-36.9560",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::wastewater-inlet-daily-raw-water-quality-eastern-treatment-plant-etp"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_ETP_Daily_InfluentQuality_From2014/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wastewater-inlet-daily-raw-water-quality-eastern-treatment-plant-etp.geojson"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wastewater-inlet-daily-raw-water-quality-eastern-treatment-plant-etp.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=ca7365ea0e5a4258ac20e7d376233444&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::wastewater-outlet-hourly-flow-eastern-treatment-plant-etp-",
-			"title": "Wastewater Outlet - Hourly Flow - Eastern Treatment Plant (ETP) ",
-			"description": "<div>The Eastern Treatment Plant (ETP) discharges treated effluent  in accordance with EPA Victoria licence AL74284 to an ocean outfall at Boag Rocks. This file contains hourly flowrate data at the treatment plant pumpstation. From the pumpstation, the effluent takes several hours (typically 4-8 h) to reach the ocean.</div><div><br /></div><div>NOTE. Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"wastewater",
-				"treatment",
-				"sewage",
-				"sewerage",
-				"volume",
-				"flowrate",
-				"melbourne",
-				"eastern treatment plant"
-			],
-			"issued": "2019-09-05T13:20:12.000Z",
-			"modified": "2019-09-05T14:30:57.334Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "143.5310,-38.8620,146.6510,-36.9560",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::wastewater-outlet-hourly-flow-eastern-treatment-plant-etp-"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_ETP_Hourly_EffluentFlow_From2009/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wastewater-outlet-hourly-flow-eastern-treatment-plant-etp-.geojson"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wastewater-outlet-hourly-flow-eastern-treatment-plant-etp-.csv"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=b217c542a6f8496c8d8daca40e87cd67&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-main-pipelines-other-authority",
-			"title": "Water Supply Main Pipelines (Other Authority)",
-			"description": "Layer containing water supply main centrelines for other authorities (assets not owned by Melbourne Water). This layer is generated from data received from other Water Authorities (Barwon Water, Gippsland Water, DELWP and other). This layer supports Melbourne Water to reference the existence and indicative location of water supply mains and their likely inter-connectivity with Melbourne Water assets. This layer is intended to be used for reference purpose only. Relevant authorities would need to be contacted if the data is to be used other than for reference.<div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"water main",
-				"other authority",
-				"centreline",
-				"water supply",
-				"melbourne",
-				"wholesale infrastructure",
-				"assets"
-			],
-			"issued": "2019-11-13T05:38:36.000Z",
-			"modified": "2019-11-15T05:21:18.723Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.3096,-38.5638,145.9432,-37.8307",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-main-pipelines-other-authority"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Water_Supply_Main_Pipelines_(Other_Authority)/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-main-pipelines-other-authority.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-main-pipelines-other-authority.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/5cd164e3234e4a6da38cb19afe5bcf58/geojson?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "KML",
 					"format": "KML",
 					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-main-pipelines-other-authority.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-main-pipelines-other-authority.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/5cd164e3234e4a6da38cb19afe5bcf58/kml?layers=0"
 				}
 			],
 			"theme": [
@@ -1774,76 +150,40 @@
 		},
 		{
 			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=fa9f51b6a3284c0095efe460e8da3db7&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::catchments-primary-catchments-of-melbournes-river-basins",
-			"title": "Catchments - Primary Catchments of Melbourne's River Basins",
-			"description": "<div>Area representing the watershed catchment of a waterway or the hydraulic catchment of an underground stormwater drain for each Melbourne Water drain / catchment number. Captured using available contours and underground stormwater pipe network information. This layer is intended:</div><div><ol><li>To enable the identification of the receiving Melbourne Water waterway/drain for any property, area or point.</li><li>To provide a framework of catchments for hydrologic modelling that can be further divided or amalgamated to suit the needs of the modeller.</li></ol></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.<br /></div>",
+			"identifier": "https://www.arcgis.com/home/item.html?id=4419fdd588f74f59a8785371f8ef291b",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/content/4419fdd588f74f59a8785371f8ef291b",
+			"title": "Central highlands Water Data Hub",
+			"description": "{{description}}",
 			"keyword": [
-				"drainage",
-				"waterways",
-				"underground drains",
-				"catchments",
-				"melbourne",
-				"stormwater",
-				"land",
-				"drainage network"
+				"Hub Site"
 			],
-			"issued": "2019-10-07T00:02:06.000Z",
-			"modified": "2019-10-28T04:13:48.636Z",
+			"issued": "2025-01-15T03:26:34.000Z",
+			"modified": "2025-04-14T22:31:19.000Z",
 			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
+				"name": "Central Highlands Water"
 			},
 			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
+				"@type": "vcard:Contact",
+				"fn": "CentralHighlandsWater_chw",
+				"hasEmail": "{{orgContactEmail}}"
 			},
 			"accessLevel": "public",
-			"spatial": "144.0494,-39.0996,147.9639,-37.2254",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
+			"spatial": "112.9197,-55.1168,159.2562,-9.1406",
+			"license": "",
 			"distribution": [
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS Hub Dataset",
 					"format": "Web Page",
 					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::catchments-primary-catchments-of-melbournes-river-basins"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/content/4419fdd588f74f59a8785371f8ef291b"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS GeoService",
 					"format": "ArcGIS GeoServices REST API",
 					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Primary_Drainage_Catchment/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-primary-catchments-of-melbournes-river-basins.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-primary-catchments-of-melbournes-river-basins.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-primary-catchments-of-melbournes-river-basins.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-primary-catchments-of-melbournes-river-basins.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com"
 				}
 			],
 			"theme": [
@@ -1852,74 +192,31 @@
 		},
 		{
 			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=49efc083a61749e6b3f5001669cbbdae&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::catchments-major-river-basins-melbourne",
-			"title": "Catchments - Major River Basins Melbourne",
-			"description": "<div>River basin catchment areas for Melbourne.  This layer has two intended purposes: </div><div><ol><li>To provide a readily available amalgamation of MWC_Catchments that make up the river basins within Melbourne Water’s area. </li><li>Useful for larger scale plans and maps.</li></ol></div><div>Data for basin boundaries have been captured by relevant State and Territory authorities from 1:10 000 and 1:250 000 scale source material. The balance of the data are from Geoscience Australia's GEODATA Coast 100K which includes coastlines and State and Territory borders. Topographic Drainage Divisions and River Region boundaries are updated based on current research, data and technology. It references previous work of the Australian Water Resources Management Committee as shown in Australia's River Basins 1997. This work is a collaboration of scientists from the Bureau of Meteorology, Australian National University Fenner School of Environment and Society, CSIRO Water for Healthy Country Flagship and Geoscience Australia.<br /></div><div><br /></div><div>In late 2008, the Bureau of Meteorology (BoM), in partnership with Geoscience Australia, CSIRO and the Australian National University (ANU) commenced the development of the Australian Hydrological Geospatial Fabric (Geofabric). Geofabric is being developed to underpin the Australian Water Resources Information System (AWRIS) within a single, consistent, national geospatial framework for hydrological features. Geoscience Australia's role in the Geofabric is to provide the best available national topographic spatial data for surface water features based on the National Topographic Data and Map Specifications. The river basin boundaries have been aligned (by Melbourne Water) to Melbourne Water Corporation (MWC) drainage catchments, to produce a consistent drainage and waterways catchment dataset to State level, since 2005.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"drainage",
-				"waterways",
-				"catchments",
-				"melbourne",
-				"river basins",
-				"land"
-			],
-			"issued": "2019-10-07T00:01:52.000Z",
-			"modified": "2021-09-15T00:20:55.621Z",
+			"identifier": "https://www.arcgis.com/home/item.html?id=72d808ed7d4e476880992ff77f9d5413",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/maps/72d808ed7d4e476880992ff77f9d5413",
+			"title": "CHWAreaMapBlue",
+			"description": "<p>display CHW service area</p>",
+			"keyword": [],
+			"issued": "2025-01-15T05:22:39.000Z",
+			"modified": "2025-03-11T22:22:39.000Z",
 			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
+				"name": "Central Highlands Water"
 			},
 			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
+				"@type": "vcard:Contact",
+				"fn": "CentralHighlandsWater_chw",
+				"hasEmail": "{{orgContactEmail}}"
 			},
 			"accessLevel": "public",
-			"spatial": "144.0723,-38.5425,146.1698,-37.2264",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
+			"spatial": "142.1251,-38.3050,145.0090,-36.3970",
+			"license": "",
 			"distribution": [
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS Hub Dataset",
 					"format": "Web Page",
 					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::catchments-major-river-basins-melbourne"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Catchments_of_Major_Waterways/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-major-river-basins-melbourne.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-major-river-basins-melbourne.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-major-river-basins-melbourne.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-major-river-basins-melbourne.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/maps/72d808ed7d4e476880992ff77f9d5413"
 				}
 			],
 			"theme": [
@@ -1928,79 +225,71 @@
 		},
 		{
 			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=e2f77d27e5d14edb815453031dc3ed6b&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::land-owned-by-melbourne-water",
-			"title": "Land Owned by Melbourne Water",
-			"description": "<div>Layer containing polygons that denote the location and extent of parcels of land that are owned by Melbourne Water. This layer is intended to be used to identify Melbourne Water owned land and responsibilities for the management of Melbourne Water assets. Layer shows general location of assets only and so cannot be used for detailed mapping or analysis.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
+			"identifier": "https://www.arcgis.com/home/item.html?id=2b40a9239bb74c6eb4486bd73c774946&sublayer=0",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/2b40a9239bb74c6eb4486bd73c774946_0",
+			"title": "Central Highlands Water Recycled Mains",
+			"description": "<p>Data containing recycled water mains in the Central Highland Water service area.<br>Please note: Although Central Highlands Water takes great care in managing its data, we make no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Central Highlands Water shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.<br></p>",
 			"keyword": [
-				"melbourne water",
-				"land",
-				"mwc",
-				"property",
-				"ownership",
-				"water supply",
-				"wastewater",
-				"sewerage",
-				"drainage",
-				"waterways",
-				"reserve"
+				"Recyled Water open data",
+				"network",
+				"pipe",
+				"recycled water"
 			],
-			"issued": "2019-09-02T06:18:28.000Z",
-			"modified": "2021-09-15T00:21:06.275Z",
+			"issued": "2024-12-17T00:36:25.000Z",
+			"modified": "2026-07-18T19:07:15.248Z",
 			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
+				"name": "Central Highlands Water"
 			},
 			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
+				"@type": "vcard:Contact",
+				"fn": "nic.hendriks@chw.net.au_chw",
+				"hasEmail": "{{orgContactEmail}}"
 			},
 			"accessLevel": "public",
-			"spatial": "144.3896,-38.4808,146.4212,-37.1726",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
+			"spatial": "143.3787,-37.6217,144.2701,-36.9305",
+			"license": "<p>Creative Commons Attribution Share-Alike 4.0 International</p>",
 			"distribution": [
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS Hub Dataset",
 					"format": "Web Page",
 					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::land-owned-by-melbourne-water"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/2b40a9239bb74c6eb4486bd73c774946_0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS GeoService",
 					"format": "ArcGIS GeoServices REST API",
 					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MWC_Owned_Land_OpenData/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::land-owned-by-melbourne-water.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://services9.arcgis.com/JGBDKYQnfMPTEusx/arcgis/rest/services/CHW_RecycledMains_view/FeatureServer/0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "CSV",
 					"format": "CSV",
 					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::land-owned-by-melbourne-water.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::land-owned-by-melbourne-water.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/2b40a9239bb74c6eb4486bd73c774946/csv?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "Shapefile",
 					"format": "ZIP",
 					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::land-owned-by-melbourne-water.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/2b40a9239bb74c6eb4486bd73c774946/shapefile?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "GeoJSON",
+					"format": "GeoJSON",
+					"mediaType": "application/vnd.geo+json",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/2b40a9239bb74c6eb4486bd73c774946/geojson?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "KML",
+					"format": "KML",
+					"mediaType": "application/vnd.google-earth.kml+xml",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/2b40a9239bb74c6eb4486bd73c774946/kml?layers=0"
 				}
 			],
 			"theme": [
@@ -2009,227 +298,71 @@
 		},
 		{
 			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=7754f292286342a99baf7c26e8f7463e&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-habitat-suitability-modelling-results-for-macroinvertebrates",
-			"title": "HWS2018 Habitat suitability modelling results for Macroinvertebrates",
-			"description": "<div>Data describes habitat suitability modelling (HSM) results for macroinvertebrates in streams. The data was developed by University of Melbourne through the Melbourne Waterways Research Practice Partnership as part of the development of Melbourne Water’s Healthy Waterways Strategy 2018 (HWS2018). Analysis has been undertaken across the Melbourne Water operating region, where the operating region has been divided into 16,346 sub-catchments. Of these 16,346 subcatchments, 8233 contain Melbourne Water waterways. The results are presented for each of these 8233 reaches. The data was used to estimate the scores for macroninvertebrates presented in the HWS for three scenarios:</div><div><ul><li>Current: habitat suitability under current conditions (i.e. 2014).</li><li>Current trajectory: habitat suitability under urbanisation and climate change scenarios if current management approaches continue.</li><li>Target trajectory: habitat suitability given urbanisation and climate change (as for current trajectory), together with (a) delivery of performance objectives of the Healthy Waterways Strategy and (b) achievement of environmental condition scores as described in the Catchment Programs of the Healthy Waterways Strategy.</li></ul></div><div>Data has also been captured for a range of modelled HSM scenarios involving revegetation, stormwater management and climate change. Primary purpose is for waterways planning and analysis.</div><div><br /></div><div>Habitat Suitability Model results have been thoroughly reviewed and are considered fit for purpose (i.e. for waterway planning). This data set covers the entire Melbourne Water region with the exception of very small areas close to Port Phillip Bay or Western Port. For example, there are small areas of French Island which are not captured.</div><div><br /></div><div>This data set was created using: 1. Streams dataset for the Healthy Waterways Strategy 2018. This layer was developed by GraceGIS using Melbourne Water layers as inputs. 2. Results from Habitat Suitability Modelling for the Healthy Waterways Strategy 2018. </div><div><br /></div><div>Further reading: Chee et al. (in development), Habitat Suitability Models, Scenarios and Quantitative Action Prioritisation (using Zonation) for Melbourne Water’s Healthy Waterways Strategy: A Resource Document, University of Melbourne and Melbourne Water for Melbourne Waterways Research Practice Partnership</div><div>Melbourne Water (in development), Healthy Waterways Strategy Resource Document.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
+			"identifier": "https://www.arcgis.com/home/item.html?id=0a5afc67bdf84365ac48888de7c80303&sublayer=0",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/0a5afc67bdf84365ac48888de7c80303_0",
+			"title": "Central Highlands Water Sewer Sidelines",
+			"description": "<p>Data containing sewer sidelines in the Central Highland Water service area.<br>Please note: Although Central Highlands Water takes great care in managing its data, we make no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Central Highlands Water shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.<br></p>",
 			"keyword": [
-				"Habitat Suitability Modelling 2018",
-				"Macroinvertebrates",
-				"Bugs",
-				"Waterways",
-				"Instream",
-				"Land",
-				"Healthy Waterways Strategy 2018"
-			],
-			"issued": "2019-09-05T14:19:42.000Z",
-			"modified": "2019-09-05T14:20:13.323Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0836,-38.4941,146.1648,-37.2301",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-habitat-suitability-modelling-results-for-macroinvertebrates"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/MACROS_HSM_HWS/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-macroinvertebrates.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-macroinvertebrates.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-macroinvertebrates.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-macroinvertebrates.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=edb323c130374cf38733d955a93fc4eb&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-service-reservoirs-local-system-storage",
-			"title": "Water Supply Service Reservoirs (Local System Storage)",
-			"description": "<div>Layer containing water supply service reservoirs (location and extent). Service reservoirs are minor local storages. Information captured using as-constructed drawings and aerial imagery, and includes service reservoir name, category / type, asset identifier, as-constructed plan references plus other key attributes. This layer is intended to be used to locate and obtain details on Melbourne Water's water supply transfer assets for asset management, buildover (Dial-Before-You-Dig) and operational or maintenance purposes.</div><div><br /></div><div>This layer is updated when new information is received from completed projects and/or updated from certified survey plans. Melbourne Water are responsible for reviewing and accepting information which results in update to the existing layer. </div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"water supply assets",
-				"water supply",
-				"transfer network",
-				"wholesale",
-				"infrastructure assets",
-				"reservoirs"
-			],
-			"issued": "2019-09-03T03:19:03.000Z",
-			"modified": "2019-09-03T04:20:15.056Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.6519,-38.3392,145.9115,-37.2433",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-service-reservoirs-local-system-storage"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/WS_Service_Reservoir_OpenData/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-service-reservoirs-local-system-storage.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-service-reservoirs-local-system-storage.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-service-reservoirs-local-system-storage.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-service-reservoirs-local-system-storage.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=4f7855d35fbf445f8d45dbeefdc117b4&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::eastern-treatment-plant-supernatant-main",
-			"title": "Eastern Treatment Plant Supernatant Main",
-			"description": "<div><div>Eastern Treatment Plant (ETP) is a wastewater treatment facility. This layer contains <font size='3'>the ETP supernatant pipeline centrelines and associated details.  Includes sewer name, description, asset section (for As Constructed drawings) and key attributes. This layer supports Melbourne Water to communicate the existence and indicative location of sewer assets within its responsibility; to ensure they are protected throughout asset life. This layer is intended to be used for asset management, buildover (Dial-Before-You-Dig) and operational / maintenance purposes. </font></div><div><font size='3'><br /></font></div><div><font size='3'>This layer is updated when new information is received from completed projects and updated from certified survey plans.</font></div></div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div><div><br /></div>",
-			"keyword": [
-				"Treatment Plant",
-				"Supernatant",
-				"Main",
-				"ETP",
+				"CHW_Open_Sewer_Data",
 				"sewer",
-				"wastewater"
+				"pipes",
+				"network"
 			],
-			"issued": "2019-11-13T06:34:35.000Z",
-			"modified": "2019-11-15T05:04:26.702Z",
+			"issued": "2024-12-17T00:34:57.000Z",
+			"modified": "2026-07-18T19:07:03.118Z",
 			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
+				"name": "Central Highlands Water"
 			},
 			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
+				"@type": "vcard:Contact",
+				"fn": "nic.hendriks@chw.net.au_chw",
+				"hasEmail": "{{orgContactEmail}}"
 			},
 			"accessLevel": "public",
-			"spatial": "145.1649,-38.0751,145.1846,-38.0413",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
+			"spatial": "143.3535,-37.7352,144.2415,-37.0184",
+			"license": "<p>Creative Commons Attribution Share-Alike 4.0 International</p>",
 			"distribution": [
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS Hub Dataset",
 					"format": "Web Page",
 					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::eastern-treatment-plant-supernatant-main"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/0a5afc67bdf84365ac48888de7c80303_0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS GeoService",
 					"format": "ArcGIS GeoServices REST API",
 					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Eastern_Treatment_Plant_Supernatant_Main/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-supernatant-main.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://services9.arcgis.com/JGBDKYQnfMPTEusx/arcgis/rest/services/CHW_SewerSidelines_view/FeatureServer/0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "CSV",
 					"format": "CSV",
 					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-supernatant-main.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-supernatant-main.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/0a5afc67bdf84365ac48888de7c80303/csv?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "Shapefile",
 					"format": "ZIP",
 					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-supernatant-main.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/0a5afc67bdf84365ac48888de7c80303/shapefile?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "GeoJSON",
+					"format": "GeoJSON",
+					"mediaType": "application/vnd.geo+json",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/0a5afc67bdf84365ac48888de7c80303/geojson?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "KML",
+					"format": "KML",
+					"mediaType": "application/vnd.google-earth.kml+xml",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/0a5afc67bdf84365ac48888de7c80303/kml?layers=0"
 				}
 			],
 			"theme": [
@@ -2238,307 +371,71 @@
 		},
 		{
 			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=a6d917c9bf3c466fb99304cc27034662&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::western-treatment-plant-carrier-and-main-pipelines",
-			"title": "Western Treatment Plant Carrier and Main Pipelines",
-			"description": "Western Treatment Plant (WTP) is a wastewater treatment facility. This layer contains the WTP carrier and mains and associated details. Includes sewer name, description, asset section (for As Constructed drawings) and key attributes. This layer supports Melbourne Water to communicate high level data in regards to the existence and indicative location of assets within its responsibility to ensure they are protected throughout the assets life.<div><br /></div><div>This layer is updated when new information is received from completed projects and updated from certified survey plans. </div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
+			"identifier": "https://www.arcgis.com/home/item.html?id=f8460cbf39554f57b48ccf87fe0613b6&sublayer=0",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/f8460cbf39554f57b48ccf87fe0613b6_0",
+			"title": "Central Highlands Water Water Valves",
+			"description": "<p>Data containing water valves in the Central Highland Water service area.</p><p>Please note: Although Central Highlands Water takes great care in managing its data, we make no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Central Highlands Water shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</p>",
 			"keyword": [
-				"Main",
-				"Treatment Plant",
-				"WTP",
-				"Carrier",
-				"Sewer",
-				"wastewater"
-			],
-			"issued": "2019-11-14T13:33:22.000Z",
-			"modified": "2019-11-15T04:55:57.516Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.4946,-38.0483,144.6756,-37.9310",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::western-treatment-plant-carrier-and-main-pipelines"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Western_Treatment_Plant_Carrier_and_Mains/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::western-treatment-plant-carrier-and-main-pipelines.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::western-treatment-plant-carrier-and-main-pipelines.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::western-treatment-plant-carrier-and-main-pipelines.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::western-treatment-plant-carrier-and-main-pipelines.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=c88a41b40ed6425f91845fd8f7f1c6a6&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::catchments-major-catchments-of-melbournes-river-basins",
-			"title": "Catchments - Major Catchments of Melbourne's River Basins",
-			"description": "<div>Area representing the watershed / hydraulic catchment of major waterways. The &quot;Major Catchment&quot; layer divides each Primary catchment into the tributaries of a primary river. The delineation of a Major Catchment is by the watershed (natural or constructed) of a major drain or watercourse. Examples of major catchments are: Tributary of Yarra River, Darebin Creek, Tarago River and Corhanwarrbul Creek. This dataset provides a consolidated and consistent set of drainage catchments covering the entire Port Phillip and Westernport catchment area (Melbourne Water’s area of responsibility for waterways and drainage). The primary purpose of this layer is for the hydraulic modelling of catchments and waterways, and/or calculations. Additional uses: </div><div><ul><li>Asset creation and numbering</li><li>Flood Plain Mapping</li><li>Drainage Scheme Creation and Reviews</li><li>Water Resource Management</li><li>Responding to Land Development Queries</li></ul></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.<br /></div>",
-			"keyword": [
-				"major catchments",
-				"drainage",
-				"waterways",
-				"catchments",
-				"melbourne",
-				"land"
-			],
-			"issued": "2019-10-06T03:20:49.000Z",
-			"modified": "2020-05-07T23:31:24.483Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0723,-38.5425,146.1698,-37.2264",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::catchments-major-catchments-of-melbournes-river-basins"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Major_Waterways_Drains_and_Tributaries_Catchments/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-major-catchments-of-melbournes-river-basins.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-major-catchments-of-melbournes-river-basins.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-major-catchments-of-melbournes-river-basins.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::catchments-major-catchments-of-melbournes-river-basins.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=e7f55cf51fdb4bcd912ac1151a8d401a&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::eastern-treatment-plant-digester-sludge-main",
-			"title": "Eastern Treatment Plant Digester Sludge Main",
-			"description": "Eastern Treatment Plant is a wastewater treatment facility. This layer contains the Eastern Treatment Plant Digester Sludge pipeline centre lines and associated details.  Includes sewer name, description, asset section (for As Constructed drawings) and key attributes. This layer supports Melbourne Water to communicate the existence and indicative location of sewer assets within its responsibility; to ensure they are protected throughout asset life. This layer is intended to be used for asset management, buildover (Dial-Before-You-Dig) and operational / maintenance purposes. <div><br /></div><div>This layer is updated when new information is received from completed projects and updated from certified survey plans.</div><div><br /><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div></div>",
-			"keyword": [
-				"Treatment Plant",
-				"Sludge",
-				"Digester",
-				"Main",
-				"ETP",
-				"sewer",
-				"wastewater"
-			],
-			"issued": "2019-11-14T12:43:00.000Z",
-			"modified": "2019-11-15T05:07:18.005Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "145.1624,-38.0768,145.1843,-38.0419",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::eastern-treatment-plant-digester-sludge-main"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Eastern_Treatment_Plant_Digester_Sludge_Main/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-digester-sludge-main.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-digester-sludge-main.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-digester-sludge-main.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-digester-sludge-main.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=a8a9b5a6282b47ed877659304883a3ad&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::wetland-and-lake-assets",
-			"title": "Wetland and Lake Assets",
-			"description": "<div>Location and extent of Melbourne Water natural and constructed (man-made) wetlands and lakes. Captured using the Top Water Level (TWL) of each, includes wetland or lake name, asset section (for As Constructed drawings) and key attributes. Data set required to indicate the location and types of assets used for stormwater treatment (treatment and removal of pollutants from the stormwater system) and flow management (helping maintain the flow of water and reduce the impacts of floods), for ongoing condition monitoring, maintenance and hydrologic or vegetation analysis and to assist with the planning and design, construction of future stormwater management (WSUD) options.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"infrastructure assets",
+				"CHW_Open_Water_Data",
+				"network",
 				"water",
-				"waterbodies",
-				"melbourne water",
-				"drainage",
-				"wetlands",
-				"lakes",
-				"stormwater",
-				"treatment",
-				"constructed"
+				"valves"
 			],
-			"issued": "2019-10-07T04:45:30.000Z",
-			"modified": "2022-01-11T23:02:35.615Z",
+			"issued": "2024-12-17T02:26:45.000Z",
+			"modified": "2026-07-18T19:09:22.901Z",
 			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
+				"name": "Central Highlands Water"
 			},
 			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
+				"@type": "vcard:Contact",
+				"fn": "nic.hendriks@chw.net.au_chw",
+				"hasEmail": "{{orgContactEmail}}"
 			},
 			"accessLevel": "public",
-			"spatial": "144.1682,-38.4918,145.9096,-37.3215",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
+			"spatial": "143.0957,-37.9035,144.3197,-36.9002",
+			"license": "<p><span style='background-color:rgb(255,255,255);color:rgb(102,102,102);font-family:&quot;Bliss Regular&quot;, &quot;Avenir Next&quot;;font-size:16px;'><span style='-webkit-text-stroke-width:0px;display:inline !important;float:none;font-style:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-decoration-color:initial;text-decoration-style:initial;text-decoration-thickness:initial;text-indent:0px;text-transform:none;white-space:normal;widows:2;word-spacing:0px;'>Creative Commons Attribution Share-Alike 4.0 International</span></span></p>",
 			"distribution": [
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS Hub Dataset",
 					"format": "Web Page",
 					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::wetland-and-lake-assets"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/f8460cbf39554f57b48ccf87fe0613b6_0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS GeoService",
 					"format": "ArcGIS GeoServices REST API",
 					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Constructed_Wetland_Stormwater_Quality_Assets/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wetland-and-lake-assets.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://services9.arcgis.com/JGBDKYQnfMPTEusx/arcgis/rest/services/CHW_WaterValves_view/FeatureServer/0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "CSV",
 					"format": "CSV",
 					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wetland-and-lake-assets.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wetland-and-lake-assets.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/f8460cbf39554f57b48ccf87fe0613b6/csv?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "Shapefile",
 					"format": "ZIP",
 					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::wetland-and-lake-assets.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/f8460cbf39554f57b48ccf87fe0613b6/shapefile?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "GeoJSON",
+					"format": "GeoJSON",
+					"mediaType": "application/vnd.geo+json",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/f8460cbf39554f57b48ccf87fe0613b6/geojson?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "KML",
+					"format": "KML",
+					"mediaType": "application/vnd.google-earth.kml+xml",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/f8460cbf39554f57b48ccf87fe0613b6/kml?layers=0"
 				}
 			],
 			"theme": [
@@ -2547,75 +444,217 @@
 		},
 		{
 			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=bcbd557eea1040579257535408894e3e&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::eastern-treatment-plant-4w-effluent-main",
-			"title": "Eastern Treatment Plant 4W Effluent Main",
-			"description": "<div>Eastern Treatment Plant (ETP) is a wastewater treatment facility. Non-potable water, known as 4W, is generated and used onsite. This layer contains the 4W Effluent pipeline centrelines and associated details.  Includes sewer name, description, asset section (for As Constructed drawings) and key attributes. This layer supports Melbourne Water to communicate high level data in regards to the existence and indicative location of assets within its responsibility to ensure they are protected throughout the assets life.</div><div><br /></div><div>This layer is updated when new information is received from completed projects and updated from certified survey plans. </div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
+			"identifier": "https://www.arcgis.com/home/item.html?id=d8d7073cb60845238c8fdf3da9e777b4&sublayer=0",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/d8d7073cb60845238c8fdf3da9e777b4_0",
+			"title": "Central Highlands Water Recycled Fireplugs",
+			"description": "<p>Data containing recycled water fireplugs in the Central Highland Water service area.<br>Please note: Although Central Highlands Water takes great care in managing its data, we make no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Central Highlands Water shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.<br></p>",
 			"keyword": [
-				"effluent",
-				"ETP",
-				"treatment plant",
-				"4W Main",
+				"Recyled Water open data",
+				"network",
+				"fireplug"
+			],
+			"issued": "2024-12-17T02:09:32.000Z",
+			"modified": "2026-07-18T19:07:21.487Z",
+			"publisher": {
+				"name": "Central Highlands Water"
+			},
+			"contactPoint": {
+				"@type": "vcard:Contact",
+				"fn": "nic.hendriks@chw.net.au_chw",
+				"hasEmail": "{{orgContactEmail}}"
+			},
+			"accessLevel": "public",
+			"spatial": "143.7928,-37.5282,143.8023,-37.5094",
+			"license": "<p>Creative Commons Attribution Share-Alike 4.0 International</p>",
+			"distribution": [
+				{
+					"@type": "dcat:Distribution",
+					"title": "ArcGIS Hub Dataset",
+					"format": "Web Page",
+					"mediaType": "text/html",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/d8d7073cb60845238c8fdf3da9e777b4_0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "ArcGIS GeoService",
+					"format": "ArcGIS GeoServices REST API",
+					"mediaType": "application/json",
+					"accessURL": "https://services9.arcgis.com/JGBDKYQnfMPTEusx/arcgis/rest/services/CHW_RecycledFireplugs_view/FeatureServer/0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "CSV",
+					"format": "CSV",
+					"mediaType": "text/csv",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/d8d7073cb60845238c8fdf3da9e777b4/csv?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "Shapefile",
+					"format": "ZIP",
+					"mediaType": "application/zip",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/d8d7073cb60845238c8fdf3da9e777b4/shapefile?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "GeoJSON",
+					"format": "GeoJSON",
+					"mediaType": "application/vnd.geo+json",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/d8d7073cb60845238c8fdf3da9e777b4/geojson?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "KML",
+					"format": "KML",
+					"mediaType": "application/vnd.google-earth.kml+xml",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/d8d7073cb60845238c8fdf3da9e777b4/kml?layers=0"
+				}
+			],
+			"theme": [
+				"geospatial"
+			]
+		},
+		{
+			"@type": "dcat:Dataset",
+			"identifier": "https://www.arcgis.com/home/item.html?id=3b4b5e8c522243f5a15f3aad32915b11&sublayer=0",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/3b4b5e8c522243f5a15f3aad32915b11_0",
+			"title": "Central Highlands Water Fireplugs",
+			"description": "<p>Data containing water fireplugs and hydrants in the Central Highland Water service area.<br>Please note: Although Central Highlands Water takes great care in managing its data, we make no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Central Highlands Water shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.<br></p>",
+			"keyword": [
+				"CHW_Open_Water_Data",
+				"water",
+				"network",
+				"fireplug",
+				"hydrant"
+			],
+			"issued": "2024-12-17T02:10:37.000Z",
+			"modified": "2026-07-18T19:07:49.690Z",
+			"publisher": {
+				"name": "Central Highlands Water"
+			},
+			"contactPoint": {
+				"@type": "vcard:Contact",
+				"fn": "nic.hendriks@chw.net.au_chw",
+				"hasEmail": "{{orgContactEmail}}"
+			},
+			"accessLevel": "public",
+			"spatial": "143.0957,-37.9041,144.3220,-36.8981",
+			"license": "<p>Creative Commons Attribution Share-Alike 4.0 International</p>",
+			"distribution": [
+				{
+					"@type": "dcat:Distribution",
+					"title": "ArcGIS Hub Dataset",
+					"format": "Web Page",
+					"mediaType": "text/html",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/3b4b5e8c522243f5a15f3aad32915b11_0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "ArcGIS GeoService",
+					"format": "ArcGIS GeoServices REST API",
+					"mediaType": "application/json",
+					"accessURL": "https://services9.arcgis.com/JGBDKYQnfMPTEusx/arcgis/rest/services/CHW_Fireplugs_view/FeatureServer/0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "CSV",
+					"format": "CSV",
+					"mediaType": "text/csv",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/3b4b5e8c522243f5a15f3aad32915b11/csv?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "Shapefile",
+					"format": "ZIP",
+					"mediaType": "application/zip",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/3b4b5e8c522243f5a15f3aad32915b11/shapefile?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "GeoJSON",
+					"format": "GeoJSON",
+					"mediaType": "application/vnd.geo+json",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/3b4b5e8c522243f5a15f3aad32915b11/geojson?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "KML",
+					"format": "KML",
+					"mediaType": "application/vnd.google-earth.kml+xml",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/3b4b5e8c522243f5a15f3aad32915b11/kml?layers=0"
+				}
+			],
+			"theme": [
+				"geospatial"
+			]
+		},
+		{
+			"@type": "dcat:Dataset",
+			"identifier": "https://www.arcgis.com/home/item.html?id=7561118c551b4d6fa10042d74aacc612&sublayer=0",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/7561118c551b4d6fa10042d74aacc612_0",
+			"title": "Central Highlands Water Sewer Maintenance Holes",
+			"description": "<p>Data containing sewer maintenance holes in the Central Highland Water service area.<br>Please note: Although Central Highlands Water takes great care in managing its data, we make no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Central Highlands Water shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.<br></p>",
+			"keyword": [
+				"CHW_Open_Sewer_Data",
 				"sewer",
-				"onsite recycling",
-				"wastewater"
+				"network",
+				"maintenance holes"
 			],
-			"issued": "2019-11-15T04:10:14.000Z",
-			"modified": "2019-11-15T05:10:34.690Z",
+			"issued": "2024-12-17T02:13:15.000Z",
+			"modified": "2026-07-18T19:08:53.421Z",
 			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
+				"name": "Central Highlands Water"
 			},
 			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
+				"@type": "vcard:Contact",
+				"fn": "nic.hendriks@chw.net.au_chw",
+				"hasEmail": "{{orgContactEmail}}"
 			},
 			"accessLevel": "public",
-			"spatial": "145.1458,-38.0674,145.1764,-38.0538",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
+			"spatial": "143.3535,-37.6920,144.2415,-37.0000",
+			"license": "<p>Creative Commons Attribution Share-Alike 4.0 International</p>",
 			"distribution": [
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS Hub Dataset",
 					"format": "Web Page",
 					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::eastern-treatment-plant-4w-effluent-main"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/7561118c551b4d6fa10042d74aacc612_0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS GeoService",
 					"format": "ArcGIS GeoServices REST API",
 					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Eastern_Treatment_Plant_4W_Effluent_Main/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-4w-effluent-main.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://services9.arcgis.com/JGBDKYQnfMPTEusx/arcgis/rest/services/CHW_SewerMaintenanceHoles_view/FeatureServer/0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "CSV",
 					"format": "CSV",
 					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-4w-effluent-main.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-4w-effluent-main.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/7561118c551b4d6fa10042d74aacc612/csv?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "Shapefile",
 					"format": "ZIP",
 					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-4w-effluent-main.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/7561118c551b4d6fa10042d74aacc612/shapefile?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "GeoJSON",
+					"format": "GeoJSON",
+					"mediaType": "application/vnd.geo+json",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/7561118c551b4d6fa10042d74aacc612/geojson?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "KML",
+					"format": "KML",
+					"mediaType": "application/vnd.google-earth.kml+xml",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/7561118c551b4d6fa10042d74aacc612/kml?layers=0"
 				}
 			],
 			"theme": [
@@ -2624,75 +663,106 @@
 		},
 		{
 			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=07e011c3e36f4b0aa8023d096d5a50a8&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::frog-census-records",
-			"title": "Frog Census Records",
-			"description": "This dataset is a compilation of Frog Census records (citizen science program) and the preceding Frog Watch program for the Port Phillip and Westernport CMA Region. These presence-only records collected in an ad-hoc manner are combined with regional frog records form the Victorian Biodiversity Atlas (VBA) and results of Melbourne Water commissioned surveys for frogs. The latter data are largely targeting threatened species of frog.<div><br /></div><div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div></div>",
+			"identifier": "https://www.arcgis.com/home/item.html?id=8a5933397ef54092bd8efb52016a365b&sublayer=0",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/8a5933397ef54092bd8efb52016a365b_0",
+			"title": "Central Highlands Water Water Mains",
+			"description": "<p>Data containing water mains in the Central Highland Water service area.</p><p>Please note: Although Central Highlands Water takes great care in managing its data, we make no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Central Highlands Water shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</p>",
 			"keyword": [
-				"Biodiversity",
-				"Fauna",
-				"Frogs",
-				"Amphibians",
-				"Victoria",
-				"Port Phillip and Westernport Region",
-				"Melbourne"
+				"CHW_Open_Water_Data",
+				"water",
+				"pipes",
+				"network"
 			],
-			"issued": "2019-09-05T10:31:47.000Z",
-			"modified": "2022-05-27T00:41:43.783Z",
+			"issued": "2024-12-16T03:47:28.000Z",
+			"modified": "2026-07-18T19:11:01.168Z",
 			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
+				"name": "Central Highlands Water"
 			},
 			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
+				"@type": "vcard:Contact",
+				"fn": "nic.hendriks@chw.net.au_chw",
+				"hasEmail": "{{orgContactEmail}}"
 			},
 			"accessLevel": "public",
-			"spatial": "143.4904,-39.0217,146.4396,-37.0331",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
+			"spatial": "143.0956,-37.9044,144.3220,-36.8981",
+			"license": "<p><span style=\"background-color:rgb(255,255,255);color:rgb(102,102,102);font-family:&quot;Bliss Regular&quot;, &quot;Avenir Next&quot;;font-size:16px;\"><span style=\"-webkit-text-stroke-width:0px;display:inline !important;float:none;font-style:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:start;text-decoration-color:initial;text-decoration-style:initial;text-decoration-thickness:initial;text-indent:0px;text-transform:none;white-space:normal;widows:2;word-spacing:0px;\">Creative Commons Attribution Share-Alike 4.0 International</span></span></p>",
 			"distribution": [
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS Hub Dataset",
 					"format": "Web Page",
 					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::frog-census-records"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/8a5933397ef54092bd8efb52016a365b_0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS GeoService",
 					"format": "ArcGIS GeoServices REST API",
 					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Frog_Location_OpenData/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::frog-census-records.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://services9.arcgis.com/JGBDKYQnfMPTEusx/arcgis/rest/services/CHW_WaterMains_view/FeatureServer/0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "CSV",
 					"format": "CSV",
 					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::frog-census-records.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::frog-census-records.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/8a5933397ef54092bd8efb52016a365b/csv?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "Shapefile",
 					"format": "ZIP",
 					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::frog-census-records.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/8a5933397ef54092bd8efb52016a365b/shapefile?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "GeoJSON",
+					"format": "GeoJSON",
+					"mediaType": "application/vnd.geo+json",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/8a5933397ef54092bd8efb52016a365b/geojson?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "KML",
+					"format": "KML",
+					"mediaType": "application/vnd.google-earth.kml+xml",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/8a5933397ef54092bd8efb52016a365b/kml?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "File Geodatabase",
+					"format": "ZIP",
+					"mediaType": "application/zip",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/8a5933397ef54092bd8efb52016a365b/filegdb?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "Feature Collection",
+					"format": "TXT",
+					"mediaType": "text/plain",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/8a5933397ef54092bd8efb52016a365b/featureCollection?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "Excel",
+					"format": "XLSX",
+					"mediaType": "application/vnd.ms-excel",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/8a5933397ef54092bd8efb52016a365b/excel?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "GeoPackage",
+					"format": "GPKG",
+					"mediaType": "application/geopackage+sqlite3",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/8a5933397ef54092bd8efb52016a365b/geoPackage?layers=0"
+				},
+				{
+					"@type": "dcat:Distribution",
+					"title": "SQLite Geodatabase",
+					"format": "GDB",
+					"mediaType": "application/geopackage+sqlite3",
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/8a5933397ef54092bd8efb52016a365b/sqlite?layers=0"
 				}
 			],
 			"theme": [
@@ -2701,601 +771,71 @@
 		},
 		{
 			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=05b5509d3526423c82e1409e9bf8b7ac&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-catchments-for-melbourne-water",
-			"title": "Water Supply Catchments for Melbourne Water",
-			"description": "<div>Layer containing water supply system catchment boundaries for water harvesting in the region of Melbourne. Includes catchment name, type, size of catchment and asset identifier. The type are defined by CATCHO (Open), CATCHC (Closed), and CATCH (Restricted). This layer is intended for general mapping purposes and internal use only, and is not to be used for detailed mapping of, or detailed calculation related to, water supply catchments.</div><div><br /></div><div>This layer is updated when new information is received from completed projects and/or updated from certified survey plans. Melbourne Water are responsible for reviewing and accepting information which results in update to the existing layer. Dataset also includes additional catchments captured originally e.g. Graceburn and Donnellys Weir.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
+			"identifier": "https://www.arcgis.com/home/item.html?id=9f4d0b99ed3b4184bc8a90276a7632aa&sublayer=0",
+			"landingPage": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/9f4d0b99ed3b4184bc8a90276a7632aa_0",
+			"title": "Central Highlands Water Sewer Mains",
+			"description": "<p>Data containing sewer mains in the Central Highland Water service area.</p><p><br />Please note: Although Central Highlands Water takes great care in managing its data, we make no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Central Highlands Water shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.<br /></p>",
 			"keyword": [
-				"catchment boundaries",
-				"water supply",
-				"transfer network",
-				"wholesale",
-				"assets",
-				"water harvesting"
-			],
-			"issued": "2019-09-03T01:39:02.000Z",
-			"modified": "2019-09-15T23:53:38.481Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.8723,-38.3125,146.4106,-37.3559",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::water-supply-catchments-for-melbourne-water"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/WS_Catchment_OpenData/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-catchments-for-melbourne-water.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-catchments-for-melbourne-water.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-catchments-for-melbourne-water.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::water-supply-catchments-for-melbourne-water.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=4f254fdf618e4668b450d7b6a6bd2a2a&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-subcatchment-boundaries",
-			"title": "HWS2018 Subcatchment Boundaries",
-			"description": "<div>As part of the Healthy Waterways Strategy 2018 (HWS2018) the Melbourne Water operating region was split into a series of sub-regions. This includes 5 catchments, and 69 sub-catchments. The boundaries of each region generally follow catchment boundaries. There are two separate spatial scales:- Catchments (5 regions: Werribee, Maribyrnong, Yarra, Dandenong, Westernport) and Sub-catchments (69 polygons). This dataset is an update to the Regional River Health Strategy (RRHS) Management Units layer created in 2008. Primary purpose of this data is for reporting of targets, performance objectives, conditions, values etc. relating to the Healthy Waterways Strategy.</div><div><br /></div><div>The sub-catchments in this dataset are an update of the &quot;management units&quot; developed for the Regional River Health Strategy in 2008. This dataset was created by merging sub-catchments from the University of Melbourne sub-catchments layer, commonly referred to as the DCI layer (where DCI refers to Directly Connected Imperviousness). The catchment polygons in this layer are similar to, but not exactly the same as those in the DCI layer currently used internally at Melbourne Water - The internally used layer has 15,901 polygon catchments, whilst the layer used to create this dataset has 16,346 polygon catchments. The Melbourne Water internal dataset will shortly be updated to align.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Healthy Waterways Strategy 2018",
-				"Waterways",
-				"Management Unit",
-				"Drainage",
-				"Stormwater",
-				"Catchment",
-				"Subcatchment",
-				"Boundary",
-				"Land"
-			],
-			"issued": "2019-09-05T14:07:34.000Z",
-			"modified": "2019-09-05T14:08:01.283Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0723,-38.5425,146.1698,-37.2264",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-subcatchment-boundaries"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/HWS_Subcatchments/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-subcatchment-boundaries.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-subcatchment-boundaries.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-subcatchment-boundaries.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-subcatchment-boundaries.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=ed5fe433145b4e1cb786bb50f1c629da&sublayer=0",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::eastern-treatment-plant-3w-effluent-main",
-			"title": "Eastern Treatment Plant 3W Effluent Main",
-			"description": "<div>Eastern Treatment Plant (ETP) is a wastewater treatment facility. Utility water, known as 3W, is generated and used onsite. This layer contains the 3W pipeline centrelines and associated details.  Includes pipeline name, description, asset section (for As Constructed drawings) and key attributes. This layer supports Melbourne Water to communicate the existence and indicative location of sewer assets within its responsibility; to ensure they are protected throughout asset life. This layer is intended to be used for asset management and operational / maintenance purposes. </div><div><br /><div>This layer is updated when new information is received from completed projects and updated from certified survey plans. </div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div></div>",
-			"keyword": [
-				"effluent",
-				"ETP",
-				"treatment plant",
-				"3W Main",
+				"CHW_Open_Sewer_Data",
+				"pipes",
 				"sewer",
-				"wasterwater",
-				"onsite recycling"
+				"network"
 			],
-			"issued": "2019-11-15T04:07:05.000Z",
-			"modified": "2019-11-15T05:13:25.460Z",
+			"issued": "2024-12-16T04:52:59.000Z",
+			"modified": "2026-07-18T19:03:44.348Z",
 			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
+				"name": "Central Highlands Water"
 			},
 			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
+				"@type": "vcard:Contact",
+				"fn": "nic.hendriks@chw.net.au_chw",
+				"hasEmail": "{{orgContactEmail}}"
 			},
 			"accessLevel": "public",
-			"spatial": "145.1572,-38.0740,145.1856,-38.0461",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
+			"spatial": "143.0969,-37.7352,144.2581,-36.9642",
+			"license": "<p>Creative Commons Attribution Share-Alike 4.0 International</p>",
 			"distribution": [
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS Hub Dataset",
 					"format": "Web Page",
 					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::eastern-treatment-plant-3w-effluent-main"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/datasets/9f4d0b99ed3b4184bc8a90276a7632aa_0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "ArcGIS GeoService",
 					"format": "ArcGIS GeoServices REST API",
 					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Eastern_Treatment_Plant_3W_Effluent_Main/FeatureServer/0"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-3w-effluent-main.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://services9.arcgis.com/JGBDKYQnfMPTEusx/arcgis/rest/services/CHW_SewerMains_view/FeatureServer/0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "CSV",
 					"format": "CSV",
 					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-3w-effluent-main.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-3w-effluent-main.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/9f4d0b99ed3b4184bc8a90276a7632aa/csv?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "Shapefile",
 					"format": "ZIP",
 					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::eastern-treatment-plant-3w-effluent-main.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=80575fa5c8a84daab04b6a8893d7842c&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-stormwater-priority-areas",
-			"title": "HWS2018 Stormwater Priority Areas",
-			"description": "<div>This layer describes the stormwater priority areas for Melbourne Water’s Healthy Waterways Strategy 2018 (HWS2018). Stormwater priority areas were determined by a combination of decision support tools and the co-design process. The decision support tool used was Zonation, which prioritised management actions across the region with the objective of improving instream habitat suitability for platypus, fish and macroinvertebrates. The stormwater priority area polygons were created by merging sub-catchments from University of Melbourne’s subc layer, i.e. the network of sub-catchments used for assessing attenuated imperviousness and for habitat suitability modelling. </div><div><br /></div><div>Primary purpose for this data is identifying stormwater priority areas of Melbourne Water's Healthy Waterways Strategy 2018. This dataset covers the Greater Melbourne region with the stormwater priority areas presented in this dataset aligning with the priorities of the Melbourne Water Healthy Waterways Strategy 2018. However, it is important to note that stormwater management activities require additional judgement to consider whether areas beyond (e.g. upstream) of the priority areas identified will also require treatment to achieve the desired waterway health outcomes.</div><div><br /></div><div>The harvesting and infiltration targets presented in this dataset provide an estimate of what is required to achieve stormwater disconnection and recreation of the natural hydrology. However, is should be noted that these values are approximate only and do not replace site-specific investigations. The values have been calculated in reference to Walsh et al. 2012 , who presented target ranges for infiltration and harvesting required to achieve urban stormwater disconnection (i.e. re-creation of forested/vegetated hydrology). The values presented are the average of the ranges estimated by Walsh et al. 2012. These values do not replace a detailed site investigation. Site-specific factors (soil type, topography, geology and other hydrological features of the catchment) will influence the appropriate targets for a site.</div><div><br /></div><div>For further reading on the prioritisation process see:</div><div><ul><li>Chee et al. (in development), Habitat Suitability Models, Scenarios and Quantitative Action Prioritisation (using Zonation) for Melbourne Water’s Healthy Waterways Strategy: A Resource Document, University of Melbourne and Melbourne Water for Melbourne Waterways Research Practice Partnership</li><li>Melbourne Water (in development), Healthy Waterways Strategy Resource Document. Each priority area contains targets for harvesting and infiltration. Achievement of these targets is required to achieve stormwater disconnection. These targets are presented in two ways: per impervious hectare, and total volume to full urban development (i.e. complete urban development to the urban growth boundary). It should be noted that these targets are approximate values only and do not replace site-specific studies. See notes above about how target values were selected.</li></ul></div><div>For further reading, see: Walsh, C. J., Fletcher, T. D., &amp; Burns, M. J. (2012). Urban stormwater runoff: a new class of environmental flow problem. PLoS One, 7(9)<br /></div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Healthy Waterways Strategy 2018",
-				"Stormwater",
-				"Harvest",
-				"Infiltrate",
-				"Waterways",
-				"Hydrology",
-				"Impervious",
-				"Disconnection",
-				"Land"
-			],
-			"issued": "2019-09-05T14:10:57.000Z",
-			"modified": "2019-10-28T04:00:33.909Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0749,-38.4788,146.1698,-37.2264",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-stormwater-priority-areas"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/STORMWATER_PRIORITY_AREAS_HWS/FeatureServer/1"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/9f4d0b99ed3b4184bc8a90276a7632aa/shapefile?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "GeoJSON",
 					"format": "GeoJSON",
 					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-stormwater-priority-areas.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-stormwater-priority-areas.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/9f4d0b99ed3b4184bc8a90276a7632aa/geojson?layers=0"
 				},
 				{
 					"@type": "dcat:Distribution",
 					"title": "KML",
 					"format": "KML",
 					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-stormwater-priority-areas.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-stormwater-priority-areas.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=ed76606730d5410392ab2d1f222a35dc&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-habitat-suitability-modelling-results-for-fish",
-			"title": "HWS2018 Habitat suitability modelling results for Fish",
-			"description": "<div>Data describes habitat suitability modelling (HSM) results for fish in streams. The data was developed by University of Melbourne through the Melbourne Waterways Research Practice Partnership as part of the development of Melbourne Water’s Healthy Waterways Strategy 2018 (HWS2018). Analysis has been undertaken across the Melbourne Water operating region, where the operating region has been divided into 16,346 sub-catchments. Of these 16,346 subcatchments, 8233 contain Melbourne Water waterways. The results are presented for each of these 8233 reaches for these HWS scenarios:</div><div><ul><li>Current: habitat suitability for fish under current conditions (i.e. 2014).</li><li>Current trajectory: habitat suitability for fish under urbanisation and climate change scenarios if current management approaches continue. </li><li>Target trajectory: habitat suitability for fish given urbanisation and climate change (as for current trajectory), together with (a) delivery of performance objectives of the Healthy Waterways Strategy and (b) achievement of environmental condition scores as described in the Catchment Programs of the Healthy Waterways Strategy.</li></ul></div><div>Results are presented as:</div><div><ul><li>Stacked probabilities, i.e. habitat suitability all 13 native fished species added together. These stacked probability values were used in the HWS to provide a fish value score each reach and sub-catchments.</li><li>Results are also provided for all 22 fish species. Presentation of habitat suitabilty model results for fish from the Healthy Waterways Strategy 2018.</li></ul></div><div><br /></div><div>Habitat Suitability Model results have been thoroughly reviewed and are considered fit for purpose (i.e. for waterway planning). This data set covers the entire Melbourne Water region with the exception of very small areas close to Port Phillip Bay or Western Port. For example, there are small areas of French Island which are not captured.</div><div><br /></div><div>This data set was created using: 1. Streams dataset for the Healthy Waterways Strategy 2018 (developed by GraceGIS using Melbourne Water layers as inputs), and 2. Results from Habitat Suitability Modelling for the Healthy Waterways Strategy 2018. </div><div><br /></div><div>Further reading: Chee et al. (in development), Habitat Suitability Models, Scenarios and Quantitative Action Prioritisation (using Zonation) for Melbourne Water’s Healthy Waterways Strategy: A Resource Document, University of Melbourne and Melbourne Water for Melbourne Waterways Research Practice Partnership Melbourne Water (in development), Healthy Waterways Strategy Resource Document</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Habitat Suitability Modelling 2018",
-				"Fish",
-				"Galaxias",
-				"Waterways",
-				"Streams",
-				"Habitat",
-				"Healthy Waterways Strategy 2018",
-				"Land"
-			],
-			"issued": "2019-09-05T14:16:01.000Z",
-			"modified": "2019-09-05T14:23:06.804Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0836,-38.4941,146.1648,-37.2301",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::hws2018-habitat-suitability-modelling-results-for-fish"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/FISH_HSM_HWS/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-fish.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-fish.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-fish.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::hws2018-habitat-suitability-modelling-results-for-fish.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=1f7bd55e1fd548ec8aa464b8c04e109d",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::community-perceptions-of-water-in-melbourne-in-2019-1",
-			"title": "Community Perceptions of Water in Melbourne in 2019",
-			"description": "<div>This data was collected in June 2019 from 799 residents aged 18+ in the Greater Melbourne Region to capture and monitor: </div><div>-Community perceptions and concerns about water in Melbourne</div><div>-Awareness and attitudes toward water sources</div><div>-Attitude towards water conservation and restrictions</div><div>-Water literacy in the community</div><div>-Perceptions of Melbourne Water’s brand and industry performance</div><div>-Exposure to flood and understanding of flood management and responsible authorities.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"Open Data",
-				"water supply",
-				"wastewater",
-				"drainage",
-				"waterways",
-				"land",
-				"water security",
-				"community perceptions",
-				"water literacy",
-				"alternative water sources",
-				"Melbourne water",
-				"flood awareness",
-				"saving water",
-				"water conservation",
-				"willingness to pay"
-			],
-			"issued": "2019-09-03T05:05:18.000Z",
-			"modified": "2019-10-17T07:31:24.000Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "143.5310,-38.8620,146.6510,-36.9560",
-			"license": "<a href='http://creativecommons.org/licenses/by-sa/4.0/'><img alt='Creative Commons License' src='https://i.creativecommons.org/l/by-sa/4.0/88x31.png' style='border-width:0;' /></a><br />This work is licensed under a <a href='http://creativecommons.org/licenses/by-sa/4.0/'>Creative Commons Attribution-ShareAlike 4.0 International License</a> under the following terms:<div><ul><li>Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.</li><li>ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.</li></ul></div>",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::community-perceptions-of-water-in-melbourne-in-2019-1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=74bb2fffc57b4208b830843f609e5639&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::waterways-centreline",
-			"title": "Waterways Centreline",
-			"description": "<div>Layer containing line objects delineating hydrological features, representing waterways managed by Melbourne Water (i.e. catchment size is greater than 60 hectares) that have not been significantly modified by human activity. Captured by digitizing a line along the centre of a linear geographic feature. Includes the waterway name, a unique asset identifier, EPMS/asset section number (to link the object to associated drawings) and key attributes to assist with its intended purpose. </div><div><br /></div><div>When used in conjunction with the constructed waterways centreline and waterway connector centreline layers, this layer completes the waterway/hydrology linear network (complete centreline) for Melbourne Water’s non-underground drainage assets. </div><div><br /></div><div>Data set is used to indicate the location and types of natural waterways for asset management and maintenance works, to assess buildover or planning applications, for waterway rehabilitation works and flow management (helping maintain the flow of water and reduce the impacts of floods), ongoing condition monitoring and hydrologic modelling and analysis and to assist with the planning and design, construction of new waterway corridors, stormwater management (WSUD) options.</div><div><br /></div><div>Waterway (Reach) layer created from original FIS 1:50K (Vicmap Hydro) streams data set which included only those waterways within catchments of greater than 60ha. Waterways (Reach) Rectification project undertaken 2001 to 2003 to review and correct the extent of the waterways reach network to ensure a complete data set exists (using the Drainage Metropolis Boundary, 50K data, 1:2500 Drainage Record Plans, Drainage Limits data, orthophotos, as constructed and/or design drawings, contour data and Melway Street Directory). Waterway (Reach) extents defined and attributes populated in GIS and AMIS for all records including assigning nodes and node numbers (for start / end points) and removing any reaches less than 100 metres in length that are predominantly channel assets. Waterways in extended area incorporated in 2005 using Vicmap Hydro data and aerial imagery, then updated in 2009/10 using Lidar survey data (contours). Data is maintained using Lidar survey data (contours) and 60 ha limits. Please refer to metadata for each record in dataset for specific source / accuracy information.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"melbourne water",
-				"drainage",
-				"waterways",
-				"centreline",
-				"natural assets",
-				"land",
-				"rivers",
-				"streams"
-			],
-			"issued": "2019-10-07T04:44:26.000Z",
-			"modified": "2020-08-14T02:26:08.248Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.0834,-38.4993,146.1648,-37.2301",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::waterways-centreline"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Centreline_of_the_Waterway/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::waterways-centreline.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::waterways-centreline.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::waterways-centreline.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::waterways-centreline.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				}
-			],
-			"theme": [
-				"geospatial"
-			]
-		},
-		{
-			"@type": "dcat:Dataset",
-			"identifier": "https://www.arcgis.com/home/item.html?id=327d0d7f2403444e81a90be764fa9092&sublayer=1",
-			"landingPage": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::waterway-structures",
-			"title": "Waterway Structures",
-			"description": "<div>Polygons representing natural waterway or channel structure locations (such as sediment ponds, litter traps, weirs, spillways, drop structures) and associated details. Includes description, asset section (for As Constructed drawings) and key attributes. This layer is intended to help identify the location of Melbourne Water's drainage assets for asset management and maintenance purposes.</div><div><br /></div><div>Waterway (Reach) layer created from original FIS 1:50K (Vicmap Hydro) streams data set which included only those waterways within catchments of greater than 60ha. Waterways (Reach) Rectification project undertaken 2001 to 2003 to review and correct the extent of the waterways reach network to ensure a complete data set exists (using the Drainage Metropolis Boundary, 50K data, 1:2500 Drainage Record Plans, Drainage Limits data, orthophotos, as constructed and/or design drawings, contour data and Melway Street Directory). Waterway (Reach) extents defined and attributes populated in GIS and Hansen (AMIS) for all records including assigning nodes and node numbers (for start / end points) and removing any reaches less than 100 metres in length that are predominantly channel assets. Waterways in extended area incorporated in 2005 using Vicmap Hydro data and aerial imagery, then updated in 2009/10 using Lidar survey data (contours). Data is maintained using Lidar survey data (contours) and 60 ha limits. Please refer to metadata for each record in dataset for specific source / accuracy information.</div><div><br /></div><div>NOTE: Whilst every effort has been taken in collecting, validating and providing the attached data, Melbourne Water Corporation makes no representations or guarantees as to the accuracy or completeness of this data. Any person or group that uses this data does so at its own risk and should make their own assessment and investigations as to the suitability and/or application of the data. Melbourne Water Corporation shall not be liable in any way to any person or group for loss of any kind including damages, costs, interest, loss of profits or special loss or damage, arising from any use, error, inaccuracy, incompleteness or other defect in this data.</div>",
-			"keyword": [
-				"infrastructure assets",
-				"waterway",
-				"channel",
-				"sediment ponds",
-				"traps",
-				"weirs",
-				"spillways",
-				"melbourne",
-				"drainage",
-				"jetty"
-			],
-			"issued": "2019-10-07T04:48:22.000Z",
-			"modified": "2019-10-08T02:12:36.428Z",
-			"publisher": {
-				"source": "Melbourne Water Corporation",
-				"name": "Melbourne Water Corporation"
-			},
-			"contactPoint": {
-				"fn": "Melbourne Water Corporation",
-				"hasEmail": "mailto:enquiry@melbournewater.com.au",
-				"@type": "vcard:Contact"
-			},
-			"accessLevel": "public",
-			"spatial": "144.2171,-38.4767,145.8851,-37.3729",
-			"license": "Creative Commons Attribution Share-Alike 4.0 International",
-			"distribution": [
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS Hub Dataset",
-					"format": "Web Page",
-					"mediaType": "text/html",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/maps/melbournewater::waterway-structures"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "ArcGIS GeoService",
-					"format": "ArcGIS GeoServices REST API",
-					"mediaType": "application/json",
-					"accessURL": "https://services5.arcgis.com/ZSYwjtv8RKVhkXIL/arcgis/rest/services/Waterway_Structures_OpenData/FeatureServer/1"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "GeoJSON",
-					"format": "GeoJSON",
-					"mediaType": "application/vnd.geo+json",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::waterway-structures.geojson?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "CSV",
-					"format": "CSV",
-					"mediaType": "text/csv",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::waterway-structures.csv?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "KML",
-					"format": "KML",
-					"mediaType": "application/vnd.google-earth.kml+xml",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::waterway-structures.kml?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
-				},
-				{
-					"@type": "dcat:Distribution",
-					"title": "Shapefile",
-					"format": "ZIP",
-					"mediaType": "application/zip",
-					"accessURL": "https://data-melbournewater.opendata.arcgis.com/datasets/melbournewater::waterway-structures.zip?outSR=%7B%22latestWkid%22%3A28355%2C%22wkid%22%3A28355%7D"
+					"accessURL": "https://central-highlands-water-data-hub-chw.hub.arcgis.com/api/download/v1/items/9f4d0b99ed3b4184bc8a90276a7632aa/kml?layers=0"
 				}
 			],
 			"theme": [

--- a/ckanext/datavic_harvester/harvesters/dcat_json.py
+++ b/ckanext/datavic_harvester/harvesters/dcat_json.py
@@ -40,22 +40,49 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
     def gather_stage(self, harvest_job):
         self._set_config(harvest_job.source.config)
         self._mark_stale_harvest_objects_not_current(harvest_job.source.id)
-        return super().gather_stage(harvest_job)
+
+        object_ids = super().gather_stage(harvest_job)
+        if not object_ids:
+            return object_ids
+
+        self._restore_deleted_packages_for_reappeared_guids(
+            harvest_job.source.id, object_ids
+        )
+
+        return object_ids
 
     def import_stage(self, harvest_object):
         self._set_config(harvest_object.source.config)
 
+        # Check if the dataset has been removed.
+        # If so, let's call the parent import_stage method to handle the deletion.
+        status = "change" if self.force_import else self._get_object_extra(
+            harvest_object, "status"
+        )
+        if status == "delete" or harvest_object.content is None:
+            return super().import_stage(harvest_object)
+
         package_dict, dcat_dict = self._get_package_dict(harvest_object)
         dcat_modified = dcat_dict.get("modified")
         existing_dataset = self._get_existing_dataset(harvest_object.guid)
+        existing_package = model.Package.get(harvest_object.package_id)
+        restoring_deleted_package = (
+            status == "change"
+            and existing_package is not None
+            and existing_package.state != "active"
+        )
 
-        if dcat_modified and existing_dataset:
+        # For restored deleted packages, we want to skip below check
+        # and force the import to update the package using the parent import_stage method.
+        # This is because the package was deleted
+        # and we want to restore it with the latest information from source JSON.
+        if dcat_modified and existing_dataset and not restoring_deleted_package:
             dcat_modified = helpers.convert_date_to_isoformat(
                 dcat_modified, "modified", dcat_dict["title"]
             ).lower().split("t")[0]
 
             pkg_modified = existing_dataset['date_modified_data_asset']
-            
+
             if pkg_modified and pkg_modified == dcat_modified:
                 log.info(
                     f"Dataset with id {existing_dataset['id']} wasn't modified "
@@ -64,6 +91,64 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
                 return "unchanged"
 
         return super().import_stage(harvest_object)
+
+    def _restore_deleted_packages_for_reappeared_guids(
+        self, harvest_source_id: str, object_ids: list[str]
+    ) -> None:
+        """Reuse trashed DD packages when a deleted DCAT GUID reappears.
+
+        Upstream DCAT treats a reappeared GUID as a new harvest object because
+        the previous current object was marked non-current when the source
+        removed the dataset. For DataVic this must be a restore instead: reuse
+        the latest deleted local package_id, switch the harvest object to
+        ``change``, and let import update the package back to active. Reusing
+        the package also preserves its ``syndicated_id`` so ODP receives an
+        update for the trashed syndicated package rather than a create.
+        """
+
+        for object_id in object_ids:
+            harvest_object = HarvestObject.get(object_id)
+            if (
+                not harvest_object
+                or self._get_object_extra(harvest_object, "status") != "new"
+            ):
+                continue
+
+            package_id = self._get_latest_deleted_package_id(
+                harvest_source_id, harvest_object.guid
+            )
+            if not package_id:
+                continue
+
+            harvest_object.package_id = package_id
+            for extra in harvest_object.extras:
+                if extra.key == "status":
+                    extra.value = "change"
+                    break
+            harvest_object.save()
+
+            log.info(
+                "Restoring deleted package %s for reappeared guid %s",
+                package_id,
+                harvest_object.guid,
+            )
+
+    def _get_latest_deleted_package_id(
+        self, source_id: str, guid: str
+    ) -> Optional[str]:
+        row = (
+            model.Session.query(HarvestObject.package_id)
+            .join(model.Package, model.Package.id == HarvestObject.package_id)
+            .filter(HarvestObject.harvest_source_id == source_id)
+            .filter(HarvestObject.guid == guid)
+            .filter(HarvestObject.package_id.isnot(None))
+            .filter(HarvestObject.report_status == "deleted")
+            .filter(model.Package.state == "deleted")
+            .order_by(HarvestObject.import_finished.desc().nullslast())
+            .first()
+        )
+
+        return row[0] if row else None
 
     def _mark_stale_harvest_objects_not_current(self, harvest_source_id: str) -> None:
         """Ignore current harvest objects whose linked package has been purged."""
@@ -98,7 +183,7 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
         conversions of the data"""
 
         dcat_dict: dict[str, Any] = json.loads(harvest_object.content)
-        pkg_dict = converters.dcat_to_ckan(dcat_dict) 
+        pkg_dict = converters.dcat_to_ckan(dcat_dict)
 
         soup: BeautifulSoup = BeautifulSoup(pkg_dict["notes"], "html.parser")
 
@@ -326,14 +411,48 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
         here: str = path.abspath(path.dirname(__file__))
         with open(path.join(here, "../data/dcat_json_full_metadata.txt")) as f:
             return f.read()
-        
+
     def modify_package_dict(self, package_dict, dcat_dict, harvest_object):
         '''
             Allows custom harvesters to modify the package dict before
             creating or updating the actual package.
         '''
+        status = "change" if self.force_import else self._get_object_extra(
+            harvest_object, "status"
+        )
+        if status == "change":
+            # Make sure the package state is set to active,
+            # in case it was deleted and is now being restored.
+            package_dict["state"] = "active"
+
+            self._preserve_syndication_fields(package_dict, harvest_object)
+
         resources = package_dict["resources"]
         for resource in resources:
             resource["size"] = get_resource_size(resource["url"])
             resource["filesize"] = resource["size"]
         return package_dict
+
+    def _preserve_syndication_fields(
+        self, package_dict: dict[str, Any], harvest_object: HarvestObject
+    ) -> None:
+        """Keep DD-to-DV syndication fields that are not in the DCAT payload.
+
+        When a deleted DD package is restored, the existing syndicated_id must
+        survive the package_update so ckanext-syndicate updates the trashed DV
+        package instead of creating a new DV package.
+        """
+
+        if not harvest_object.package_id:
+            return
+
+        existing_package = model.Package.get(harvest_object.package_id)
+        if not existing_package:
+            return
+
+        for key in ("skip_syndication", "syndicated_id"):
+            value = existing_package.extras.get(key)
+            if value is None or package_dict.get(key):
+                continue
+
+            package_dict[key] = value

--- a/ckanext/datavic_harvester/harvesters/dcat_json.py
+++ b/ckanext/datavic_harvester/harvesters/dcat_json.py
@@ -7,6 +7,7 @@ from typing import Optional, Any
 
 from bs4 import BeautifulSoup
 
+from ckan import model
 from ckan.plugins import toolkit as tk
 
 from ckanext.dcat import converters
@@ -38,6 +39,7 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
 
     def gather_stage(self, harvest_job):
         self._set_config(harvest_job.source.config)
+        self._mark_stale_harvest_objects_not_current(harvest_job.source.id)
         return super().gather_stage(harvest_job)
 
     def import_stage(self, harvest_object):
@@ -59,9 +61,35 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
                     f"Dataset with id {existing_dataset['id']} wasn't modified "
                     "from the last harvest. Skipping this dataset..."
                 )
-                return False
+                return "unchanged"
 
         return super().import_stage(harvest_object)
+
+    def _mark_stale_harvest_objects_not_current(self, harvest_source_id: str) -> None:
+        """Ignore current harvest objects whose linked package has been purged."""
+
+        stale_objects = (
+            model.Session.query(HarvestObject)
+            .filter(HarvestObject.current == True)
+            .filter(HarvestObject.harvest_source_id == harvest_source_id)
+            .all()
+        )
+
+        for harvest_object in stale_objects:
+            if harvest_object.package_id and model.Package.get(
+                harvest_object.package_id
+            ):
+                continue
+
+            log.warning(
+                "Ignoring stale current harvest object for guid %s; package_id %s "
+                "does not exist",
+                harvest_object.guid,
+                harvest_object.package_id,
+            )
+            harvest_object.current = False
+            model.Session.add(harvest_object)
+            model.Session.commit()
 
     def _get_package_dict(
         self, harvest_object: HarvestObject

--- a/ckanext/datavic_harvester/harvesters/dcat_json.py
+++ b/ckanext/datavic_harvester/harvesters/dcat_json.py
@@ -66,6 +66,15 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
         dcat_modified = dcat_dict.get("modified")
         existing_dataset = self._get_existing_dataset(harvest_object.guid)
         existing_package = model.Package.get(harvest_object.package_id)
+
+        if (
+            status == "change"
+            and existing_package is None
+            and existing_dataset is None
+        ):
+            self._mark_missing_package_change_as_new(harvest_object)
+            status = "new"
+
         restoring_deleted_package = (
             status == "change"
             and existing_package is not None
@@ -91,6 +100,23 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
                 return "unchanged"
 
         return super().import_stage(harvest_object)
+
+    def _mark_missing_package_change_as_new(
+        self, harvest_object: HarvestObject
+    ) -> None:
+        log.warning(
+            "Dataset not found for status='change'. GUID: %s; package_id: %s. "
+            "Re-creating as new dataset.",
+            harvest_object.guid,
+            harvest_object.package_id,
+        )
+
+        harvest_object.package_id = None
+        for extra in harvest_object.extras:
+            if extra.key == "status":
+                extra.value = "new"
+                break
+        harvest_object.save()
 
     def _restore_deleted_packages_for_reappeared_guids(
         self, harvest_source_id: str, object_ids: list[str]

--- a/ckanext/datavic_harvester/harvesters/dcat_json.py
+++ b/ckanext/datavic_harvester/harvesters/dcat_json.py
@@ -6,6 +6,7 @@ from os import path
 from typing import Optional, Any
 
 from bs4 import BeautifulSoup
+from sqlalchemy.orm import joinedload
 
 from ckan import model
 from ckan.plugins import toolkit as tk
@@ -72,9 +73,14 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
             and existing_package is None
             and existing_dataset is None
         ):
+            # force_import overrides the status extra upstream, so clear it
+            # here or the re-create path below would still send id=None.
+            self.force_import = False
             self._mark_missing_package_change_as_new(harvest_object)
             status = "new"
 
+        # Source is the source of truth: restore regardless of how the
+        # package was trashed (source removal or a local admin delete).
         restoring_deleted_package = (
             status == "change"
             and existing_package is not None
@@ -121,28 +127,35 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
     def _restore_deleted_packages_for_reappeared_guids(
         self, harvest_source_id: str, object_ids: list[str]
     ) -> None:
-        """Reuse trashed DD packages when a deleted DCAT GUID reappears.
+        """Reuse a trashed DD package when its guid reappears in the source.
 
-        Upstream DCAT treats a reappeared GUID as a new harvest object because
-        the previous current object was marked non-current when the source
-        removed the dataset. For DataVic this must be a restore instead: reuse
-        the latest deleted local package_id, switch the harvest object to
-        ``change``, and let import update the package back to active. Reusing
-        the package also preserves its ``syndicated_id`` so ODP receives an
-        update for the trashed syndicated package rather than a create.
+        Upstream treats a reappeared guid as a new dataset. Reusing the
+        trashed package instead keeps its syndicated_id, so ODP gets an
+        update rather than a duplicate create.
         """
 
-        for object_id in object_ids:
-            harvest_object = HarvestObject.get(object_id)
-            if (
-                not harvest_object
-                or self._get_object_extra(harvest_object, "status") != "new"
-            ):
-                continue
+        harvest_objects = (
+            model.Session.query(HarvestObject)
+            .options(joinedload(HarvestObject.extras))
+            .filter(HarvestObject.id.in_(object_ids))
+            .all()
+        )
+        new_objects = [
+            harvest_object
+            for harvest_object in harvest_objects
+            if self._get_object_extra(harvest_object, "status") == "new"
+        ]
+        if not new_objects:
+            return
 
-            package_id = self._get_latest_deleted_package_id(
-                harvest_source_id, harvest_object.guid
-            )
+        deleted_package_ids = self._get_latest_deleted_package_ids(
+            harvest_source_id, [harvest_object.guid for harvest_object in new_objects]
+        )
+        if not deleted_package_ids:
+            return
+
+        for harvest_object in new_objects:
+            package_id = deleted_package_ids.get(harvest_object.guid)
             if not package_id:
                 continue
 
@@ -159,39 +172,50 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
                 harvest_object.guid,
             )
 
-    def _get_latest_deleted_package_id(
-        self, source_id: str, guid: str
-    ) -> Optional[str]:
-        row = (
-            model.Session.query(HarvestObject.package_id)
+    def _get_latest_deleted_package_ids(
+        self, source_id: str, guids: list[str]
+    ) -> dict[str, str]:
+        """Map each guid to the trashed local package that should be reused.
+
+        Matches on the trashed package alone, not ``report_status`` (which is
+        only set once an object clears the fetch queue, so it's NULL for
+        anything trashed another way). Batched into one query for all guids;
+        oldest-first ordering keeps the last write per guid as the latest
+        import.
+        """
+
+        if not guids:
+            return {}
+
+        rows = (
+            model.Session.query(HarvestObject.guid, HarvestObject.package_id)
             .join(model.Package, model.Package.id == HarvestObject.package_id)
             .filter(HarvestObject.harvest_source_id == source_id)
-            .filter(HarvestObject.guid == guid)
+            .filter(HarvestObject.guid.in_(guids))
             .filter(HarvestObject.package_id.isnot(None))
-            .filter(HarvestObject.report_status == "deleted")
             .filter(model.Package.state == "deleted")
-            .order_by(HarvestObject.import_finished.desc().nullslast())
-            .first()
+            .order_by(HarvestObject.import_finished.asc().nullsfirst())
+            .all()
         )
 
-        return row[0] if row else None
+        return {guid: package_id for guid, package_id in rows}
 
     def _mark_stale_harvest_objects_not_current(self, harvest_source_id: str) -> None:
         """Ignore current harvest objects whose linked package has been purged."""
 
         stale_objects = (
             model.Session.query(HarvestObject)
-            .filter(HarvestObject.current == True)
+            .outerjoin(model.Package, model.Package.id == HarvestObject.package_id)
+            .filter(HarvestObject.current == True)  # noqa: E712
             .filter(HarvestObject.harvest_source_id == harvest_source_id)
+            .filter(model.Package.id.is_(None))
             .all()
         )
 
-        for harvest_object in stale_objects:
-            if harvest_object.package_id and model.Package.get(
-                harvest_object.package_id
-            ):
-                continue
+        if not stale_objects:
+            return
 
+        for harvest_object in stale_objects:
             log.warning(
                 "Ignoring stale current harvest object for guid %s; package_id %s "
                 "does not exist",
@@ -200,7 +224,8 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
             )
             harvest_object.current = False
             model.Session.add(harvest_object)
-            model.Session.commit()
+
+        model.Session.commit()
 
     def _get_package_dict(
         self, harvest_object: HarvestObject
@@ -447,10 +472,7 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
             harvest_object, "status"
         )
         if status == "change":
-            # Make sure the package state is set to active,
-            # in case it was deleted and is now being restored.
-            package_dict["state"] = "active"
-
+            self._restore_package_state(package_dict, harvest_object)
             self._preserve_syndication_fields(package_dict, harvest_object)
 
         resources = package_dict["resources"]
@@ -458,6 +480,24 @@ class DataVicDCATJSONHarvester(DCATJSONHarvester, DataVicBaseHarvester):
             resource["size"] = get_resource_size(resource["url"])
             resource["filesize"] = resource["size"]
         return package_dict
+
+    def _restore_package_state(
+        self, package_dict: dict[str, Any], harvest_object: HarvestObject
+    ) -> None:
+        """Reactivate a trashed package, since the source still lists it.
+
+        state is ignore_missing in the schema and dcat_to_ckan never sets it,
+        so it must be set explicitly here or the package stays trashed.
+        """
+
+        if not harvest_object.package_id:
+            return
+
+        existing_package = model.Package.get(harvest_object.package_id)
+        if existing_package is None or existing_package.state == "active":
+            return
+
+        package_dict["state"] = "active"
 
     def _preserve_syndication_fields(
         self, package_dict: dict[str, Any], harvest_object: HarvestObject

--- a/ckanext/datavic_harvester/tests/harvesters/dcat_json/test_dcat_json.py
+++ b/ckanext/datavic_harvester/tests/harvesters/dcat_json/test_dcat_json.py
@@ -9,6 +9,7 @@ from datetime import datetime as dt
 import pytest
 
 from ckan import model
+from ckan.plugins import toolkit as tk
 from ckan.tests.helpers import call_action
 
 import ckanext.harvest.model as harvest_model
@@ -77,6 +78,82 @@ class TestDcatHarvester:
         assert stale_harvest_object.current is False
 
     @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_gather_stage_marks_reappeared_deleted_dataset_as_change(
+        self,
+        harvester: DcatHarvester,
+        harvest_job_factory,
+        harvest_source_factory,
+        harvest_object_factory,
+        dataset_factory,
+        dcat_config: DcatConfig,
+    ):
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+        dataset = dataset_factory()
+        tk.get_action("package_delete")(
+            {"user": harvester._get_user_name(), "ignore_auth": True},
+            {"id": dataset["id"]},
+        )
+        dcat_dataset = json.loads(harvester._get_mocked_content())["dataset"][0]
+        deleted_harvest_object = harvest_object_factory(
+            guid=dcat_dataset["identifier"],
+            content=None,
+            job=harvest_job,
+            package_id=dataset["id"],
+            extras={"status": "delete"},
+        )
+        deleted_harvest_object.current = False
+        deleted_harvest_object.report_status = "deleted"
+        model.Session.add(deleted_harvest_object)
+        model.Session.commit()
+
+        obj_ids = harvester.gather_stage(harvest_job)
+
+        harvest_object = harvest_model.HarvestObject.get(obj_ids[0])
+        assert harvest_object.guid == dcat_dataset["identifier"]
+        assert harvest_object.package_id == dataset["id"]
+        assert harvester._get_object_extra(harvest_object, "status") == "change"
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_gather_stage_returns_saved_delete_object_id(
+        self,
+        monkeypatch,
+        harvester: DcatHarvester,
+        harvest_job_factory,
+        harvest_source_factory,
+        harvest_object_factory,
+        dataset_factory,
+        dcat_config: DcatConfig,
+    ):
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+        dataset = dataset_factory()
+        previous_harvest_object = harvest_object_factory(
+            guid="deleted-dcat-dataset",
+            content=json.dumps({"identifier": "deleted-dcat-dataset"}),
+            job=harvest_job,
+            package_id=dataset["id"],
+            extras={"status": "new"},
+        )
+        previous_harvest_object.current = True
+        model.Session.add(previous_harvest_object)
+        model.Session.commit()
+
+        monkeypatch.setattr(harvester, "_get_mocked_content", lambda: '{"dataset":[]}')
+
+        obj_ids = harvester.gather_stage(harvest_job)
+
+        assert obj_ids
+        assert all(obj_ids)
+        harvest_object = harvest_model.HarvestObject.get(obj_ids[0])
+        assert harvest_object.package_id == dataset["id"]
+        assert harvester._get_object_extra(harvest_object, "status") == "delete"
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
     def test_import_stage(
         self,
         harvester: DcatHarvester,
@@ -141,6 +218,100 @@ class TestDcatHarvester:
         )
 
         assert harvester.import_stage(second_harvest_object) == "unchanged"
+        assert second_harvest_object.errors == []
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_import_stage_deletes_object_without_content(
+        self,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        harvest_object_factory,
+        dataset_factory,
+        dcat_config: DcatConfig,
+    ):
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+        dataset = dataset_factory()
+        harvest_object = harvest_object_factory(
+            guid="deleted-dcat-dataset",
+            content=None,
+            job=harvest_job,
+            package_id=dataset["id"],
+            extras={"status": "delete"},
+        )
+
+        assert harvester.import_stage(harvest_object) is True
+        assert model.Package.get(dataset["id"]).state == "deleted"
+        assert harvest_object.errors == []
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_import_stage_restores_deleted_dataset(
+        self,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        harvest_object_factory,
+        dcat_config: DcatConfig,
+        dcat_dataset: dict[str, Any],
+    ):
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+        first_harvest_object = harvest_object_factory(
+            guid=dcat_dataset["identifier"],
+            content=json.dumps(dcat_dataset),
+            job=harvest_job,
+        )
+
+        assert harvester.import_stage(first_harvest_object) is True
+        package_id = first_harvest_object.package_id
+        package = call_action("package_show", id=package_id)
+        package["extras"].append(
+            {"key": "syndicated_id", "value": "existing-odp-package-id"}
+        )
+        package["extras"].append({"key": "skip_syndication", "value": "false"})
+        call_action(
+            "package_update",
+            context={"user": harvester._get_user_name(), "ignore_auth": True},
+            **package,
+        )
+        tk.get_action("package_delete")(
+            {"user": harvester._get_user_name(), "ignore_auth": True},
+            {"id": package_id},
+        )
+        assert model.Package.get(package_id).state == "deleted"
+
+        second_harvest_object = harvest_object_factory(
+            guid=dcat_dataset["identifier"],
+            content=json.dumps(dcat_dataset),
+            job=harvest_job,
+            package_id=package_id,
+            extras={"status": "change"},
+        )
+
+        assert harvester.import_stage(second_harvest_object) is True
+        assert second_harvest_object.package_id == package_id
+        assert model.Package.get(package_id).state == "active"
+        package_dict, dcat_dict = harvester._get_package_dict(second_harvest_object)
+        harvester.modify_package_dict(package_dict, dcat_dict, second_harvest_object)
+        assert package_dict["syndicated_id"] == "existing-odp-package-id"
+        assert package_dict["skip_syndication"] == "false"
+        extra_keys = {extra["key"] for extra in package_dict.get("extras", [])}
+        assert "syndicated_id" not in extra_keys
+        assert "skip_syndication" not in extra_keys
+        restored_package = call_action(
+            "package_show",
+            context={"user": harvester._get_user_name(), "ignore_auth": True},
+            id=package_id,
+        )
+        assert tk.h.get_pkg_dict_extra(
+            restored_package, "syndicated_id"
+        ) == "existing-odp-package-id"
+        assert tk.h.get_pkg_dict_extra(restored_package, "skip_syndication") == "false"
         assert second_harvest_object.errors == []
 
     @pytest.mark.usefixtures("with_plugins", "clean_db")

--- a/ckanext/datavic_harvester/tests/harvesters/dcat_json/test_dcat_json.py
+++ b/ckanext/datavic_harvester/tests/harvesters/dcat_json/test_dcat_json.py
@@ -154,6 +154,76 @@ class TestDcatHarvester:
         assert harvester._get_object_extra(harvest_object, "status") == "delete"
 
     @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_gather_and_import_recreates_purged_datasets(
+        self,
+        monkeypatch,
+        harvester: DcatHarvester,
+        harvest_job_factory,
+        harvest_source_factory,
+        dcat_config: DcatConfig,
+        dcat_dataset: dict[str, Any],
+    ):
+        monkeypatch.setattr(
+            harvester,
+            "_get_mocked_content",
+            lambda: json.dumps({"dataset": [dcat_dataset]}),
+        )
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+
+        # First harvest: gather the dataset from the DCAT JSON source.
+        first_job = harvest_job_factory(source=source)
+        first_obj_ids = harvester.gather_stage(first_job)
+        first_objects = [harvest_model.HarvestObject.get(id_) for id_ in first_obj_ids]
+
+        assert first_job.gather_errors == []
+        assert len(first_objects) == 1
+        assert harvester._get_object_extra(first_objects[0], "status") == "new"
+
+        # First import: create a package from the gathered harvest object.
+        first_object = first_objects[0]
+        assert harvester.import_stage(first_object) is True
+        assert first_object.errors == []
+        self._finish_harvest_job(first_job)
+
+        original_package_id = first_object.package_id
+        assert model.Package.get(original_package_id)
+
+        # Delete and hard-purge the harvested package from CKAN.
+        self._hard_purge_harvested_packages([original_package_id])
+        assert model.Package.get(original_package_id) is None
+        first_object = harvest_model.HarvestObject.get(first_obj_ids[0])
+        assert first_object.current is True
+
+        # Second harvest: gather the same DCAT source after package purge.
+        second_job = harvest_job_factory(source=source)
+        second_obj_ids = harvester.gather_stage(second_job)
+        second_objects = [
+            harvest_model.HarvestObject.get(id_) for id_ in second_obj_ids
+        ]
+        first_objects_after_second_gather = [
+            harvest_model.HarvestObject.get(id_) for id_ in first_obj_ids
+        ]
+
+        assert second_job.gather_errors == []
+        assert len(second_objects) == 1
+        assert first_objects_after_second_gather[0].current is False
+        assert harvester._get_object_extra(second_objects[0], "status") == "new"
+        assert second_objects[0].package_id is None
+
+        # Second import: recreate the purged dataset as a new CKAN package.
+        second_object = second_objects[0]
+        assert harvester.import_stage(second_object) is True
+
+        assert second_object.errors == []
+        assert second_object.package_id != original_package_id
+        assert model.Package.get(second_object.package_id).state == "active"
+        assert model.Package.get(original_package_id) is None
+        error_text = "\n".join(str(error) for error in second_object.errors)
+        assert "Package was not found" not in error_text
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
     def test_import_stage(
         self,
         harvester: DcatHarvester,
@@ -221,6 +291,55 @@ class TestDcatHarvester:
         assert second_harvest_object.errors == []
 
     @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_import_stage_recreates_purged_dataset_from_change_object(
+        self,
+        monkeypatch,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        dcat_config: DcatConfig,
+        dcat_dataset: dict[str, Any],
+    ):
+        monkeypatch.setattr(
+            harvester,
+            "_get_mocked_content",
+            lambda: json.dumps({"dataset": [dcat_dataset]}),
+        )
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+
+        first_job = harvest_job_factory(source=source)
+        first_obj_ids = harvester.gather_stage(first_job)
+        first_harvest_object = harvest_model.HarvestObject.get(first_obj_ids[0])
+
+        assert harvester._get_object_extra(first_harvest_object, "status") == "new"
+        assert harvester.import_stage(first_harvest_object) is True
+        self._finish_harvest_job(first_job)
+        original_package_id = first_harvest_object.package_id
+        assert original_package_id
+
+        second_job = harvest_job_factory(source=source)
+        second_obj_ids = harvester.gather_stage(second_job)
+        second_harvest_object = harvest_model.HarvestObject.get(second_obj_ids[0])
+
+        assert harvester._get_object_extra(second_harvest_object, "status") == "change"
+        assert second_harvest_object.package_id == original_package_id
+
+        self._hard_purge_harvested_packages([original_package_id])
+        assert model.Package.get(original_package_id) is None
+        second_harvest_object = harvest_model.HarvestObject.get(
+            second_harvest_object.id
+        )
+
+        assert harvester.import_stage(second_harvest_object) is True
+        assert second_harvest_object.errors == []
+        assert second_harvest_object.package_id
+        assert second_harvest_object.package_id != original_package_id
+        assert model.Package.get(second_harvest_object.package_id).state == "active"
+        assert harvester._get_object_extra(second_harvest_object, "status") == "new"
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
     def test_import_stage_deletes_object_without_content(
         self,
         harvester: DcatHarvester,
@@ -270,10 +389,8 @@ class TestDcatHarvester:
         assert harvester.import_stage(first_harvest_object) is True
         package_id = first_harvest_object.package_id
         package = call_action("package_show", id=package_id)
-        package["extras"].append(
-            {"key": "syndicated_id", "value": "existing-odp-package-id"}
-        )
-        package["extras"].append({"key": "skip_syndication", "value": "false"})
+        package["syndicated_id"] = "existing-odp-package-id"
+        package["skip_syndication"] = "false"
         call_action(
             "package_update",
             context={"user": harvester._get_user_name(), "ignore_auth": True},
@@ -308,10 +425,8 @@ class TestDcatHarvester:
             context={"user": harvester._get_user_name(), "ignore_auth": True},
             id=package_id,
         )
-        assert tk.h.get_pkg_dict_extra(
-            restored_package, "syndicated_id"
-        ) == "existing-odp-package-id"
-        assert tk.h.get_pkg_dict_extra(restored_package, "skip_syndication") == "false"
+        assert restored_package["syndicated_id"] == "existing-odp-package-id"
+        assert restored_package["skip_syndication"] == "false"
         assert second_harvest_object.errors == []
 
     @pytest.mark.usefixtures("with_plugins", "clean_db")
@@ -368,3 +483,19 @@ class TestDcatHarvester:
         assert dataset == harvester._get_existing_dataset("test")
 
         assert not harvester._get_existing_dataset("test2")
+
+    def _hard_purge_harvested_packages(self, package_ids: list[str]) -> None:
+        sysadmin = call_action("get_site_user", ignore_auth=True)
+        context = {"user": sysadmin["name"], "ignore_auth": True}
+
+        for package_id in package_ids:
+            call_action("package_delete", context, id=package_id)
+
+        for package_id in package_ids:
+            call_action("dataset_purge", context, id=package_id)
+
+    def _finish_harvest_job(self, job) -> None:
+        job.status = "Finished"
+        job.gather_finished = dt.now()
+        job.finished = dt.now()
+        job.save()

--- a/ckanext/datavic_harvester/tests/harvesters/dcat_json/test_dcat_json.py
+++ b/ckanext/datavic_harvester/tests/harvesters/dcat_json/test_dcat_json.py
@@ -42,23 +42,39 @@ class TestDcatHarvester:
         harvester: DcatHarvester,
         harvest_job_factory,
         harvest_source_factory,
+        harvest_object_factory,
         dcat_config: DcatConfig,
     ):
         source = harvest_source_factory(
             config=json.dumps(dcat_config), source_type=harvester.info()["name"]
         )
         harvest_job = harvest_job_factory(source=source)
+        datasets = json.loads(harvester._get_mocked_content())["dataset"]
+        stale_harvest_object = harvest_object_factory(
+            guid=datasets[0]["identifier"],
+            content=json.dumps(datasets[0]),
+            job=harvest_job,
+            extras={"status": "change"},
+        )
+        stale_harvest_object.current = True
+        stale_harvest_object.package_id = None
+        model.Session.add(stale_harvest_object)
+        model.Session.commit()
+
         obj_ids = harvester.gather_stage(harvest_job)
 
         assert harvest_job.gather_errors == []
         assert type(obj_ids) == list
 
-        datasets = json.loads(harvester._get_mocked_content())["dataset"]
         assert len(set(obj_ids)) == len(datasets)
 
         harvest_object = harvest_model.HarvestObject.get(obj_ids[0])
         assert harvest_object.guid == datasets[0]["identifier"]
         assert json.loads(harvest_object.content) == datasets[0]
+        assert harvester._get_object_extra(harvest_object, "status") == "new"
+
+        model.Session.refresh(stale_harvest_object)
+        assert stale_harvest_object.current is False
 
     @pytest.mark.usefixtures("with_plugins", "clean_db")
     def test_import_stage(
@@ -94,6 +110,38 @@ class TestDcatHarvester:
 
         source = call_action("package_show", id=source.id)
         assert source["owner_org"] == package.owner_org
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_import_stage_returns_unchanged_when_modified_date_matches(
+        self,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        harvest_object_factory,
+        dcat_config: DcatConfig,
+        dcat_dataset: dict[str, Any],
+    ):
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+        first_harvest_object = harvest_object_factory(
+            guid=dcat_dataset["identifier"],
+            content=json.dumps(dcat_dataset),
+            job=harvest_job,
+        )
+
+        assert harvester.import_stage(first_harvest_object) is True
+
+        second_harvest_object = harvest_object_factory(
+            guid=dcat_dataset["identifier"],
+            content=json.dumps(dcat_dataset),
+            job=harvest_job,
+            extras={"status": "change"},
+        )
+
+        assert harvester.import_stage(second_harvest_object) == "unchanged"
+        assert second_harvest_object.errors == []
 
     @pytest.mark.usefixtures("with_plugins", "clean_db")
     def test_get_pkg_dict(

--- a/ckanext/datavic_harvester/tests/harvesters/dcat_json/test_dcat_json.py
+++ b/ckanext/datavic_harvester/tests/harvesters/dcat_json/test_dcat_json.py
@@ -5,6 +5,7 @@ from typing import Any
 from typing_extensions import TypedDict
 from types import GeneratorType
 from datetime import datetime as dt
+from datetime import timedelta
 
 import pytest
 
@@ -76,6 +77,40 @@ class TestDcatHarvester:
 
         model.Session.refresh(stale_harvest_object)
         assert stale_harvest_object.current is False
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_gather_stage_leaves_healthy_current_object_alone(
+        self,
+        harvester: DcatHarvester,
+        harvest_job_factory,
+        harvest_source_factory,
+        harvest_object_factory,
+        dataset_factory,
+        dcat_config: DcatConfig,
+    ):
+        """A current object whose package still exists must not be flipped."""
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+        datasets = json.loads(harvester._get_mocked_content())["dataset"]
+
+        package = dataset_factory()
+        healthy_harvest_object = harvest_object_factory(
+            guid=datasets[0]["identifier"],
+            content=json.dumps(datasets[0]),
+            job=harvest_job,
+            package_id=package["id"],
+            extras={"status": "change"},
+        )
+        healthy_harvest_object.current = True
+        model.Session.add(healthy_harvest_object)
+        model.Session.commit()
+
+        harvester.gather_stage(harvest_job)
+
+        model.Session.refresh(healthy_harvest_object)
+        assert healthy_harvest_object.current is True
 
     @pytest.mark.usefixtures("with_plugins", "clean_db")
     def test_gather_stage_marks_reappeared_deleted_dataset_as_change(
@@ -483,6 +518,319 @@ class TestDcatHarvester:
         assert dataset == harvester._get_existing_dataset("test")
 
         assert not harvester._get_existing_dataset("test2")
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_import_stage_reactivates_locally_trashed_package_still_in_source(
+        self,
+        monkeypatch,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        dcat_config: DcatConfig,
+        dcat_dataset: dict[str, Any],
+    ):
+        """An admin-trashed package still in the source must be restored."""
+        monkeypatch.setattr(
+            harvester,
+            "_get_mocked_content",
+            lambda: json.dumps({"dataset": [dcat_dataset]}),
+        )
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+
+        first_job = harvest_job_factory(source=source)
+        first_ids = harvester.gather_stage(first_job)
+        first_object = harvest_model.HarvestObject.get(first_ids[0])
+        assert harvester.import_stage(first_object) is True
+        self._finish_harvest_job(first_job)
+        package_id = first_object.package_id
+
+        tk.get_action("package_delete")(
+            {"user": harvester._get_user_name(), "ignore_auth": True},
+            {"id": package_id},
+        )
+        assert model.Package.get(package_id).state == "deleted"
+
+        second_job = harvest_job_factory(source=source)
+        second_ids = harvester.gather_stage(second_job)
+        second_object = harvest_model.HarvestObject.get(second_ids[0])
+        assert harvester._get_object_extra(second_object, "status") == "change"
+        assert second_object.package_id == package_id
+
+        assert harvester.import_stage(second_object) is True
+
+        assert model.Package.get(package_id).state == "active"
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_source_removal_then_reappearance_restores_same_package(
+        self,
+        monkeypatch,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        dcat_config: DcatConfig,
+        dcat_dataset: dict[str, Any],
+    ):
+        """A guid removed then re-added to the source restores the same package."""
+        monkeypatch.setattr(
+            harvester,
+            "_get_mocked_content",
+            lambda: json.dumps({"dataset": [dcat_dataset]}),
+        )
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+
+        first_job = harvest_job_factory(source=source)
+        first_ids = harvester.gather_stage(first_job)
+        first_object = harvest_model.HarvestObject.get(first_ids[0])
+        assert harvester.import_stage(first_object) is True
+        self._finish_harvest_job(first_job)
+        package_id = first_object.package_id
+
+        monkeypatch.setattr(harvester, "_get_mocked_content", lambda: '{"dataset":[]}')
+        delete_job = harvest_job_factory(source=source)
+        delete_ids = harvester.gather_stage(delete_job)
+        delete_object = harvest_model.HarvestObject.get(delete_ids[0])
+        assert harvester._get_object_extra(delete_object, "status") == "delete"
+        assert harvester.import_stage(delete_object) is True
+        self._finish_harvest_job(delete_job)
+        assert model.Package.get(package_id).state == "deleted"
+
+        monkeypatch.setattr(
+            harvester,
+            "_get_mocked_content",
+            lambda: json.dumps({"dataset": [dcat_dataset]}),
+        )
+        restore_job = harvest_job_factory(source=source)
+        restore_ids = harvester.gather_stage(restore_job)
+        restore_object = harvest_model.HarvestObject.get(restore_ids[0])
+
+        assert harvester._get_object_extra(restore_object, "status") == "change"
+        assert restore_object.package_id == package_id
+
+        assert harvester.import_stage(restore_object) is True
+        assert model.Package.get(package_id).state == "active"
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_modify_package_dict_leaves_state_alone_for_plain_change(
+        self,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        harvest_object_factory,
+        dcat_config: DcatConfig,
+        dcat_dataset: dict[str, Any],
+    ):
+        """state must not be sent when the package is already active."""
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+        first_object = harvest_object_factory(
+            guid=dcat_dataset["identifier"],
+            content=json.dumps(dcat_dataset),
+            job=harvest_job,
+        )
+        assert harvester.import_stage(first_object) is True
+        package_id = first_object.package_id
+
+        change_object = harvest_object_factory(
+            guid=dcat_dataset["identifier"],
+            content=json.dumps(dcat_dataset),
+            job=harvest_job,
+            package_id=package_id,
+            extras={"status": "change"},
+        )
+        package_dict, dcat_dict = harvester._get_package_dict(change_object)
+        harvester.modify_package_dict(package_dict, dcat_dict, change_object)
+
+        assert "state" not in package_dict
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_modify_package_dict_sets_state_active_for_trashed_package(
+        self,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        harvest_object_factory,
+        dcat_config: DcatConfig,
+        dcat_dataset: dict[str, Any],
+    ):
+        """state must be forced back to active when the package is trashed."""
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+        first_object = harvest_object_factory(
+            guid=dcat_dataset["identifier"],
+            content=json.dumps(dcat_dataset),
+            job=harvest_job,
+        )
+        assert harvester.import_stage(first_object) is True
+        package_id = first_object.package_id
+
+        tk.get_action("package_delete")(
+            {"user": harvester._get_user_name(), "ignore_auth": True},
+            {"id": package_id},
+        )
+        assert model.Package.get(package_id).state == "deleted"
+
+        change_object = harvest_object_factory(
+            guid=dcat_dataset["identifier"],
+            content=json.dumps(dcat_dataset),
+            job=harvest_job,
+            package_id=package_id,
+            extras={"status": "change"},
+        )
+        package_dict, dcat_dict = harvester._get_package_dict(change_object)
+        harvester.modify_package_dict(package_dict, dcat_dict, change_object)
+
+        assert package_dict["state"] == "active"
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_gather_reuses_trashed_package_without_report_status(
+        self,
+        monkeypatch,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        dcat_config: DcatConfig,
+        dcat_dataset: dict[str, Any],
+    ):
+        """The restore lookup must not depend on report_status being set."""
+        monkeypatch.setattr(
+            harvester,
+            "_get_mocked_content",
+            lambda: json.dumps({"dataset": [dcat_dataset]}),
+        )
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+
+        first_job = harvest_job_factory(source=source)
+        first_ids = harvester.gather_stage(first_job)
+        first_object = harvest_model.HarvestObject.get(first_ids[0])
+        assert harvester.import_stage(first_object) is True
+        self._finish_harvest_job(first_job)
+        original_package_id = first_object.package_id
+
+        tk.get_action("package_delete")(
+            {"user": harvester._get_user_name(), "ignore_auth": True},
+            {"id": original_package_id},
+        )
+        model.Session.query(harvest_model.HarvestObject).filter_by(
+            guid=dcat_dataset["identifier"]
+        ).update({"current": False, "report_status": None}, False)
+        model.Session.commit()
+
+        second_job = harvest_job_factory(source=source)
+        second_ids = harvester.gather_stage(second_job)
+        second_object = harvest_model.HarvestObject.get(second_ids[0])
+
+        assert second_object.package_id == original_package_id
+        assert harvester._get_object_extra(second_object, "status") == "change"
+
+        assert harvester.import_stage(second_object) is True
+        assert model.Package.get(original_package_id).state == "active"
+        assert (
+            model.Session.query(model.Package)
+            .filter(model.Package.type == "dataset")
+            .filter(model.Package.state == "active")
+            .count()
+            == 1
+        )
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_get_latest_deleted_package_ids_picks_latest_per_guid(
+        self,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        harvest_object_factory,
+        dataset_factory,
+        dcat_config: DcatConfig,
+    ):
+        """The batched lookup keeps the "latest import wins" rule per guid."""
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+        harvest_job = harvest_job_factory(source=source)
+        context = {"user": harvester._get_user_name(), "ignore_auth": True}
+
+        older = dataset_factory()
+        newer = dataset_factory()
+        other = dataset_factory()
+        for package in (older, newer, other):
+            tk.get_action("package_delete")(context, {"id": package["id"]})
+
+        now = dt.now()
+        for package, guid, import_finished in (
+            (older, "guid-a", now - timedelta(days=2)),
+            (newer, "guid-a", now),
+            (other, "guid-b", now - timedelta(days=1)),
+        ):
+            harvest_object = harvest_object_factory(
+                guid=guid,
+                content=None,
+                job=harvest_job,
+                package_id=package["id"],
+                extras={"status": "delete"},
+            )
+            harvest_object.current = False
+            harvest_object.import_finished = import_finished
+            model.Session.add(harvest_object)
+        model.Session.commit()
+
+        found = harvester._get_latest_deleted_package_ids(
+            source.id, ["guid-a", "guid-b"]
+        )
+
+        assert found["guid-a"] == newer["id"]
+        assert found["guid-b"] == other["id"]
+        assert harvester._get_latest_deleted_package_ids(source.id, []) == {}
+
+    @pytest.mark.usefixtures("with_plugins", "clean_db")
+    def test_force_import_recreates_purged_package(
+        self,
+        monkeypatch,
+        harvester: DcatHarvester,
+        harvest_source_factory,
+        harvest_job_factory,
+        dcat_config: DcatConfig,
+        dcat_dataset: dict[str, Any],
+    ):
+        """force_import against a purged package must not send id=None."""
+        monkeypatch.setattr(
+            harvester,
+            "_get_mocked_content",
+            lambda: json.dumps({"dataset": [dcat_dataset]}),
+        )
+        source = harvest_source_factory(
+            config=json.dumps(dcat_config), source_type=harvester.info()["name"]
+        )
+
+        first_job = harvest_job_factory(source=source)
+        first_ids = harvester.gather_stage(first_job)
+        first_object = harvest_model.HarvestObject.get(first_ids[0])
+        assert harvester.import_stage(first_object) is True
+        self._finish_harvest_job(first_job)
+        original_package_id = first_object.package_id
+
+        second_job = harvest_job_factory(source=source)
+        second_ids = harvester.gather_stage(second_job)
+        second_object = harvest_model.HarvestObject.get(second_ids[0])
+        assert harvester._get_object_extra(second_object, "status") == "change"
+
+        self._hard_purge_harvested_packages([original_package_id])
+        second_object = harvest_model.HarvestObject.get(second_object.id)
+        harvester.force_import = True
+
+        assert harvester.import_stage(second_object) is True
+        assert second_object.errors == []
+        assert second_object.package_id != original_package_id
+        assert model.Package.get(second_object.package_id).state == "active"
 
     def _hard_purge_harvested_packages(self, package_ids: list[str]) -> None:
         sysadmin = call_action("get_site_user", ignore_auth=True)

--- a/scripts/patches/ckanext-dcat/return-deleted-harvest-obj-ids.patch
+++ b/scripts/patches/ckanext-dcat/return-deleted-harvest-obj-ids.patch
@@ -1,0 +1,16 @@
+diff --git a/ckanext/dcat/harvesters/_json.py b/ckanext/dcat/harvesters/_json.py
+index 6600ec8..1533f9d 100644
+--- a/ckanext/dcat/harvesters/_json.py
++++ b/ckanext/dcat/harvesters/_json.py
+@@ -168,11 +168,11 @@ class DCATJSONHarvester(DCATHarvester):
+                 guid=guid, job=harvest_job,
+                 package_id=guid_to_package_id[guid],
+                 extras=[HarvestObjectExtra(key='status', value='delete')])
+-            ids.append(obj.id)
+             model.Session.query(HarvestObject).\
+                 filter_by(guid=guid).\
+                 update({'current': False}, False)
+             obj.save()
++            ids.append(obj.id)
+ 
+         return ids


### PR DESCRIPTION
https://digital-vic.atlassian.net/browse/DATAVIC-987

Changes
- Allow upstream gather logic to treat purged datasets as new harvests instead of updates
- Return `unchanged` for datasets whose DCAT modified date matches the existing package, so harvest reports them as `not modified` instead of `errored` => NOT in AC, but I noticed this issue when working on this ticket.
- Add regression coverage for stale harvest references and unchanged DCAT imports
- Updated `dcat_json_datasets.txt` for local development purpose.
- added dataset restore from trash when the guid is reappeared from the source portal.
- made sure to keep the syndicated_id intact so that syndication after restoring not creating a new package in ODP

This patch PR is required in order to have the test working https://github.com/dpc-sdp/datavic_ckan_lagoon/pull/442
