### PR TITLE
[DATAVIC-990] Send API key in X-CKAN-API-Key header when harvesting ODP

### DIFF
--- a/ckanext/datavic_harvester/harvesters/datavic_odp.py
+++ b/ckanext/datavic_harvester/harvesters/datavic_odp.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 import json
 import logging
 
+import requests
+from requests.exceptions import HTTPError, RequestException
+
 import ckan.plugins.toolkit as tk
 from ckan import model
 from ckanext.harvest.harvesters import CKANHarvester
-from ckanext.harvest.harvesters.ckanharvester import SearchError
+from ckanext.harvest.harvesters.ckanharvester import ContentFetchError, SearchError
 from ckanext.harvest.model import HarvestObject
 from ckanext.harvest_basket.harvesters.base_harvester import BasketBasicHarvester
 
@@ -155,6 +158,36 @@ class DataVicODPHarvester(CKANHarvester, BasketBasicHarvester):
         pkg_dicts = super()._search_for_datasets(remote_ckan_base_url, fq_terms)
         max_datasets = int(self.config.get("max_datasets", 0))
         return pkg_dicts[:max_datasets] if max_datasets else pkg_dicts
+
+    def _get_content(self, url):
+        """Fetch remote content, sending the API key in both the ``Authorization``
+        and ``X-CKAN-API-Key`` headers.
+
+        ODP authenticates via ``X-CKAN-API-Key`` (its configured
+        ``apitoken_header_name``), which the base ``_get_content`` does not send.
+        """
+        headers = {}
+
+        user_agent = self.config.get("user_agent")
+        if user_agent:
+            headers["User-Agent"] = str(user_agent)
+
+        api_key = self.config.get("api_key")
+        if api_key:
+            headers["Authorization"] = api_key
+            headers["X-CKAN-API-Key"] = api_key
+
+        try:
+            http_request = requests.get(url, headers=headers)
+        except HTTPError as e:
+            raise ContentFetchError(
+                "HTTP error: %s %s" % (e.response.status_code, e.request.url)
+            )
+        except RequestException as e:
+            raise ContentFetchError("Request error: %s" % e)
+        except Exception as e:
+            raise ContentFetchError("HTTP general exception: %s" % e)
+        return http_request.text
 
     def _search_datasets(self, remote_url: str):
         url = remote_url.rstrip("/") + "/api/action/package_search?rows=1"


### PR DESCRIPTION
## What
Override `_get_content` in `DataVicODPHarvester` to send the API key in **both** the `Authorization` and `X-CKAN-API-Key` headers.

## Why
ODP sets `apitoken_header_name = X-CKAN-API-Key`, so CKAN reads the API token from that header. The base `CKANHarvester._get_content` only sends `Authorization`, so authenticated harvests were treated as anonymous. ODP strips sysadmin-only custodian fields (e.g. `data_owner`) from anonymous API responses, so harvested datasets failed IAR validation on import with `data_owner: Missing value`.

Sending both headers (as `ckanapi` does) authenticates the harvester regardless of the remote's `apitoken_header_name`.

## Also required for the harvest to succeed
- A **sysadmin** `api_key` in the harvest source config.
- The DATAVIC-990 sysadmin custodian-field exemption deployed on the ODP source environment.

## Testing
Verified end-to-end against ODP with a sysadmin `api_key` in the config: `data_owner` now flows through and datasets import into DD with `data_owner` populated (previously stripped).
